### PR TITLE
Company Applicant Viewing

### DIFF
--- a/client/src/components/common/Row.css
+++ b/client/src/components/common/Row.css
@@ -1,0 +1,10 @@
+.row-container{
+    display: flex;
+    flex-direction: row;
+    text-align: left;
+    background-color: var(--color-card-bg);
+    border: 2px solid var(--color-cta-secondary-darker);
+    min-height: 4em;
+    max-width: 100%;
+    padding-left: 3em;
+}

--- a/client/src/components/common/Row.css
+++ b/client/src/components/common/Row.css
@@ -7,7 +7,7 @@
     border-bottom: 2px solid var(--color-divider);
     min-height: 4em;
     max-width: 100%;
-    padding-left: 3em;
+    padding-left: 2em;
     img{
         width: 3em;
         height: 3em;
@@ -31,19 +31,22 @@
 #row-info-email{
     display: flex;
     align-items: center;
-    width: 20%;
+    justify-content: right;
+    width: 15%;
 }
 
 #row-info-status{
     display: flex;
     align-items: center;
+    justify-content: center;
     width: 10%;
 }
 
 #row-info-date {
     display: flex;
     align-items: center;
-    width: 20%;
+    justify-content: left;
+    width: 25%;
     p{
         font-size: 1em;
     }
@@ -51,8 +54,8 @@
 
 #row-resume {
     display: flex;
-    width: 20%;
-    justify-content: right;
+    width: 30%;
+    justify-content: center;
 }
 
 

--- a/client/src/components/common/Row.css
+++ b/client/src/components/common/Row.css
@@ -2,9 +2,26 @@
     display: flex;
     flex-direction: row;
     text-align: left;
+    align-items: center;
     background-color: var(--color-card-bg);
-    border: 2px solid var(--color-cta-secondary-darker);
+    border-bottom: 2px solid var(--color-divider);
     min-height: 4em;
     max-width: 100%;
     padding-left: 3em;
+    img{
+        width: 3em;
+        height: 3em;
+        border-radius: 120px;
+    }
+    h3{
+        padding-left: 2em;
+    }
+}
+
+#row-resume-btn{
+    margin-left: 10em;
+    width: auto;
+    font-size: 1em;
+    color: white;
+    background-color: var(--color-cta-primary);
 }

--- a/client/src/components/common/Row.css
+++ b/client/src/components/common/Row.css
@@ -16,10 +16,38 @@
     h3{
         padding-left: 2em;
     }
+    p{
+        padding-left: 2em;
+        font-size: 1.1em;
+    }
 }
 
+#important-row-info{
+    display: flex;
+    align-items: center;
+    width: 20%;
+}
+
+#row-info-email{
+    display: flex;
+    align-items: center;
+    width: 20%;
+}
+
+#row-info-status{
+    display: flex;
+    align-items: center;
+    width: 15%;
+}
+
+#row-resume {
+    display: flex;
+    width: 35%;
+    justify-content: right;
+}
+
+
 #row-resume-btn{
-    margin-left: 10em;
     width: auto;
     font-size: 1em;
     color: white;

--- a/client/src/components/common/Row.css
+++ b/client/src/components/common/Row.css
@@ -18,7 +18,7 @@
     }
     p{
         padding-left: 2em;
-        font-size: 1.1em;
+        font-size: 1.2em;
     }
 }
 
@@ -37,12 +37,21 @@
 #row-info-status{
     display: flex;
     align-items: center;
-    width: 15%;
+    width: 10%;
+}
+
+#row-info-date {
+    display: flex;
+    align-items: center;
+    width: 20%;
+    p{
+        font-size: 1em;
+    }
 }
 
 #row-resume {
     display: flex;
-    width: 35%;
+    width: 20%;
     justify-content: right;
 }
 
@@ -52,4 +61,9 @@
     font-size: 1em;
     color: white;
     background-color: var(--color-cta-primary);
+}
+
+#row-resume-btn:hover{
+    background-color: var(--color-cta-secondary);
+    margin-bottom: 0.5em;
 }

--- a/client/src/components/common/Row.jsx
+++ b/client/src/components/common/Row.jsx
@@ -1,0 +1,28 @@
+import "./Row.css";
+import { useState } from "react";
+
+export default function Row({ name, id }){
+    const [image, setImage] = useState("");
+    async function getApplicantPfp(){
+        if(id){
+            const url = applicantApi.getPfpUrl(id);
+            let response = await fetch(url, {
+                method: "GET"
+            });
+        
+            if(response.status === 200){
+                const imageBlob = await response.blob();
+                const imageObjectURL = URL.createObjectURL(imageBlob);
+                setImage(imageObjectURL);
+            }
+        }
+    }
+    getApplicantPfp();
+
+    return(
+        <section className="row-container">
+            <img src={image} alt="pfp"/>
+            <h3>{name}</h3>
+        </section>
+    )
+}

--- a/client/src/components/common/Row.jsx
+++ b/client/src/components/common/Row.jsx
@@ -3,8 +3,9 @@ import { useEffect, useState } from "react";
 import { applicantApi } from "../../utils/api";
 import Modal from "./Modal";
 import ViewResumeForm from "../company-portal/ViewResumeForm";
+import { formatDate } from "../../utils/formatHelpers";
 
-export default function Row({ name, id, email, status }){
+export default function Row({ name, id, email, status, date }){
     const [image, setImage] = useState("");
     const [resumeOptions, setResumeOptions] = useState(false);
     useEffect(() => {
@@ -37,6 +38,9 @@ export default function Row({ name, id, email, status }){
                 </div>
                 <div id="row-info-status">
                     <p>{status}</p>
+                </div>
+                <div id="row-info-date">
+                    <p>{formatDate(date)}</p>
                 </div>
                 <div id="row-resume">
                     <button id="row-resume-btn" onClick={() => setResumeOptions(true)}>View Resume</button>

--- a/client/src/components/common/Row.jsx
+++ b/client/src/components/common/Row.jsx
@@ -4,7 +4,7 @@ import { applicantApi } from "../../utils/api";
 import Modal from "./Modal";
 import ViewResumeForm from "../company-portal/ViewResumeForm";
 
-export default function Row({ name, id }){
+export default function Row({ name, id, email, status }){
     const [image, setImage] = useState("");
     const [resumeOptions, setResumeOptions] = useState(false);
     useEffect(() => {
@@ -28,9 +28,19 @@ export default function Row({ name, id }){
     return(
         <>
             <section className="row-container">
-                <img src={image} alt="pfp"/>
-                <h3>{name}</h3>
-                <button id="row-resume-btn" onClick={() => setResumeOptions(true)}>View Resume</button>
+                <div id="important-row-info">
+                    <img src={image} alt="pfp"/>
+                    <h3>{name}</h3>
+                </div>
+                <div id="row-info-email">
+                    <p>{email}</p>
+                </div>
+                <div id="row-info-status">
+                    <p>{status}</p>
+                </div>
+                <div id="row-resume">
+                    <button id="row-resume-btn" onClick={() => setResumeOptions(true)}>View Resume</button>
+                </div>
             </section>
             <Modal isOpen={resumeOptions} onClose={() => setResumeOptions(false)} title={"Viewing Options"} size={"small"}>
                 <ViewResumeForm applicantId={id} />

--- a/client/src/components/common/Row.jsx
+++ b/client/src/components/common/Row.jsx
@@ -1,31 +1,40 @@
 import "./Row.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { applicantApi } from "../../utils/api";
+import Modal from "./Modal";
+import ViewResumeForm from "../company-portal/ViewResumeForm";
 
 export default function Row({ name, id }){
     const [image, setImage] = useState("");
-    async function getApplicantPfp(){
-        if(id){
-            const url = applicantApi.getPfpUrl(id);
-            let response = await fetch(url, {
-                method: "GET"
-            });
-        
-            if(response.status === 200){
-                const imageBlob = await response.blob();
-                const imageObjectURL = URL.createObjectURL(imageBlob);
-                console.log(imageObjectURL);
-                setImage(imageObjectURL);
+    const [resumeOptions, setResumeOptions] = useState(false);
+    useEffect(() => {
+        async function getApplicantPfp(){
+            if(id){
+                const url = applicantApi.getPfpUrl(id);
+                let response = await fetch(url, {
+                    method: "GET"
+                });
+            
+                if(response.status === 200){
+                    const imageBlob = await response.blob();
+                    const imageObjectURL = URL.createObjectURL(imageBlob);
+                    setImage(imageObjectURL);
+                }
             }
         }
-    }
-    getApplicantPfp();
+        getApplicantPfp();
+    }, [])
 
     return(
-        <section className="row-container">
-            <img src={image} alt="pfp"/>
-            <h3>{name}</h3>
-            <button id="row-resume-btn">View Resume</button>
-        </section>
+        <>
+            <section className="row-container">
+                <img src={image} alt="pfp"/>
+                <h3>{name}</h3>
+                <button id="row-resume-btn" onClick={() => setResumeOptions(true)}>View Resume</button>
+            </section>
+            <Modal isOpen={resumeOptions} onClose={() => setResumeOptions(false)} title={"Viewing Options"} size={"small"}>
+                <ViewResumeForm applicantId={id} />
+            </Modal>
+        </>
     )
 }

--- a/client/src/components/common/Row.jsx
+++ b/client/src/components/common/Row.jsx
@@ -23,7 +23,7 @@ export default function Row({ name, id }){
             }
         }
         getApplicantPfp();
-    }, [])
+    }, []);
 
     return(
         <>

--- a/client/src/components/common/Row.jsx
+++ b/client/src/components/common/Row.jsx
@@ -1,5 +1,6 @@
 import "./Row.css";
 import { useState } from "react";
+import { applicantApi } from "../../utils/api";
 
 export default function Row({ name, id }){
     const [image, setImage] = useState("");
@@ -13,6 +14,7 @@ export default function Row({ name, id }){
             if(response.status === 200){
                 const imageBlob = await response.blob();
                 const imageObjectURL = URL.createObjectURL(imageBlob);
+                console.log(imageObjectURL);
                 setImage(imageObjectURL);
             }
         }
@@ -23,6 +25,7 @@ export default function Row({ name, id }){
         <section className="row-container">
             <img src={image} alt="pfp"/>
             <h3>{name}</h3>
+            <button id="row-resume-btn">View Resume</button>
         </section>
     )
 }

--- a/client/src/components/common/Row.jsx
+++ b/client/src/components/common/Row.jsx
@@ -40,7 +40,7 @@ export default function Row({ name, id, email, status, date }){
                     <p>{status}</p>
                 </div>
                 <div id="row-info-date">
-                    <p>{formatDate(date)}</p>
+                    <p><strong>Applied</strong>: {formatDate(date)}</p>
                 </div>
                 <div id="row-resume">
                     <button id="row-resume-btn" onClick={() => setResumeOptions(true)}>View Resume</button>

--- a/client/src/components/company-portal/CompanyPortal.css
+++ b/client/src/components/company-portal/CompanyPortal.css
@@ -225,3 +225,17 @@
     border: none;
     cursor: pointer;
 }
+
+/* VIEW APPLICANTS SECTION */
+
+#job-details-container{
+    padding: 1em 1em 1em 3em;
+    border-bottom: 2px solid var(--color-divider);
+}
+
+.view-applicants-job-details {
+    display: flex;
+    align-items: baseline;
+    gap: 1em;
+}
+

--- a/client/src/components/company-portal/CompanyPortal.css
+++ b/client/src/components/company-portal/CompanyPortal.css
@@ -239,3 +239,7 @@
     gap: 1em;
 }
 
+#applicants-container{
+    height: 20em;
+    overflow-y: scroll;
+}

--- a/client/src/components/company-portal/CompanyPortal.css
+++ b/client/src/components/company-portal/CompanyPortal.css
@@ -38,10 +38,11 @@
 }
 
 .job-card-edit-btn {
+    color: var(--color-cta-primary);
     background-color: var(--color-card-bg-alt);
     border: 2px solid var(--color-cta-secondary-darker);
     width: 100px;
-    height: 30px;
+    height: 40px;
 }
 
 .job-card-delete-btn {

--- a/client/src/components/company-portal/CompanyPortal.css
+++ b/client/src/components/company-portal/CompanyPortal.css
@@ -227,16 +227,18 @@
 }
 
 /* VIEW APPLICANTS SECTION */
-
 #job-details-container{
-    padding: 1em 1em 1em 3em;
+    padding: 1em 1em 1em 4em;
     border-bottom: 2px solid var(--color-divider);
 }
 
 .view-applicants-job-details {
     display: flex;
     align-items: baseline;
-    gap: 1em;
+    gap: 0.75em;
+    p{
+        font-size: 1.1em;
+    }
 }
 
 #applicants-container{

--- a/client/src/components/company-portal/CompanyPortal.css
+++ b/client/src/components/company-portal/CompanyPortal.css
@@ -45,6 +45,15 @@
     height: 40px;
 }
 
+.job-card-applicant-btn {
+    color: var(--color-cta-primary);
+    background-color: var(--color-card-bg-alt);
+    border: 2px solid var(--color-cta-secondary-darker);
+    width: 110px;
+    height: 40px;
+    
+}
+
 .job-card-delete-btn {
     background-color: var(--color-cta-primary);
     border: 2px solid var(--color-cta-secondary-darker);

--- a/client/src/components/company-portal/CompanyPortal.css
+++ b/client/src/components/company-portal/CompanyPortal.css
@@ -237,7 +237,7 @@
     align-items: baseline;
     gap: 0.75em;
     p{
-        font-size: 1.1em;
+        font-size: 1.2em;
     }
 }
 

--- a/client/src/components/company-portal/CompanyPortalJobPostings.jsx
+++ b/client/src/components/company-portal/CompanyPortalJobPostings.jsx
@@ -5,6 +5,7 @@ import Card from "../common/Card.jsx";
 import Modal from "../common/Modal.jsx";
 import EditJobForm from "./EditJobForm.jsx";
 import CloseStatus from "./CloseStatus.jsx";
+import ViewApplicantsForm from "./ViewApplicantsForm.jsx";
 
 export default function CompanyPostalJobPostings({ companyId, companyName, refreshKey, editPostingId, onEditPosting }) {
     const location = useLocation();
@@ -14,6 +15,7 @@ export default function CompanyPostalJobPostings({ companyId, companyName, refre
     const [loadError, setLoadError] = useState(null);
 
     const [isEditOpen, setIsEditOpen] = useState(false);
+    const [isViewApplicantsOpen, setIsViewApplicantsOpen] = useState(false);
     const [selectedPosting, setSelectedPosting] = useState(null);
 
     const openEdit = (posting) => {
@@ -24,6 +26,16 @@ export default function CompanyPostalJobPostings({ companyId, companyName, refre
         setIsEditOpen(false);
         setSelectedPosting(null);
     };
+
+    const openApplicantsView = (posting) => {
+        setSelectedPosting(posting);
+        setIsViewApplicantsOpen(true);
+    }
+
+    const closeApplicantsView = () => {
+        setSelectedPosting(null);
+        setIsViewApplicantsOpen(false);
+    }
 
     const [postingToClose, setPostingToClose] = useState(null);
 
@@ -50,9 +62,18 @@ export default function CompanyPostalJobPostings({ companyId, companyName, refre
             (posting) => String(posting._id) === String(editPostingId)
         );
 
+        const postingToView = jobPostings.find(
+            (posting) => String(posting._id) === String(editPostingId)
+        );
+
         if (postingToEdit) {
             openEdit(postingToEdit);
             navigate(location.pathname, { replace: true, state: {} });
+        }
+
+        if(postingToView){
+            openApplicantsView(postingToView);
+            navigate(location.pathname, {replace: true, state: {} });
         }
     }, [editPostingId, jobPostings]);
 
@@ -101,6 +122,7 @@ export default function CompanyPostalJobPostings({ companyId, companyName, refre
                     <Card key={p._id} title={p.title} footer={
                         <div className="card-actions">
                             <button className="job-card-edit-btn" onClick={() => openEdit(p)}>Edit</button>
+                            <button className="job-card-applicant-btn" onClick={() => openApplicantsView(p)}>Applicants</button>
                         </div>
                     }>
                         <p><strong>Location: </strong>{p.location || "—"}</p>
@@ -143,6 +165,11 @@ export default function CompanyPostalJobPostings({ companyId, companyName, refre
                         );
                     }}
                 />
+            </Modal>
+
+            {/* View Applicants Modal */}
+            <Modal isOpen={isViewApplicantsOpen} onClose={closeApplicantsView} title={"View Applicants"}>
+                <ViewApplicantsForm posting={selectedPosting}/>
             </Modal>
 
             {/* close posting modal */}

--- a/client/src/components/company-portal/ViewApplicantsForm.jsx
+++ b/client/src/components/company-portal/ViewApplicantsForm.jsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from "react";
+
+function ViewApplicantsForm({ posting }){
+    const [companyId, setCompanyId] = useState("");
+    const [publishedAt, setPublishedAt] = useState("");
+    const [jobTitle, setJobTitle] = useState("");
+    const [totalApplicants, setTotalApplicants] = useState("");
+    const [jobApplicants, setJobApplicants] = useState([]);
+
+    useEffect(() => {
+        if(!posting) return;
+        setCompanyId(posting._id);
+        setPublishedAt(posting.publishedAt);
+        setJobTitle(posting.title);
+        setTotalApplicants(posting.applicants.length);
+        setJobApplicants(posting.applicants);
+    }, []);
+    
+
+    return(
+        <>
+
+        </>
+    )
+}
+
+export default ViewApplicantsForm;

--- a/client/src/components/company-portal/ViewApplicantsForm.jsx
+++ b/client/src/components/company-portal/ViewApplicantsForm.jsx
@@ -23,6 +23,7 @@ function ViewApplicantsForm({ posting }){
             let applicants = []
             for(let i = 0; i < jobApplicantIds.length; i++){
                 const details = await applicantApi.getById(jobApplicantIds[i]);
+                console.log(details); // REMOVE ME
                 applicants.push({
                     id: details._id,
                     name: details.name,

--- a/client/src/components/company-portal/ViewApplicantsForm.jsx
+++ b/client/src/components/company-portal/ViewApplicantsForm.jsx
@@ -1,11 +1,15 @@
 import { useState, useEffect } from "react";
+import { formatDate } from "../../utils/formatHelpers.js";
+import { applicantApi } from "../../utils/api";
+import Row from "../common/Row.jsx";
 
 function ViewApplicantsForm({ posting }){
     const [companyId, setCompanyId] = useState("");
     const [publishedAt, setPublishedAt] = useState("");
     const [jobTitle, setJobTitle] = useState("");
     const [totalApplicants, setTotalApplicants] = useState("");
-    const [jobApplicants, setJobApplicants] = useState([]);
+    const [jobApplicantIds, setJobApplicantsIds] = useState([]);
+    const [applicantDetails, setApplicantDetails] = useState([]);
 
     useEffect(() => {
         if(!posting) return;
@@ -13,13 +17,54 @@ function ViewApplicantsForm({ posting }){
         setPublishedAt(posting.publishedAt);
         setJobTitle(posting.title);
         setTotalApplicants(posting.applicants.length);
-        setJobApplicants(posting.applicants);
+        setJobApplicantsIds(posting.applicants);
     }, []);
+
+    useEffect(() => {
+        async function getApplicantDetails(){
+            let applicants = []
+            for(let i = 0; i < jobApplicantIds.length; i++){
+                const details = await applicantApi.getById(jobApplicantIds[i]);
+                applicants.push({
+                    id: details._id,
+                    name: details.name
+                });
+            }
+            setApplicantDetails(applicants);
+        }
+        getApplicantDetails();
+    }, [jobApplicantIds]);
     
 
     return(
         <>
+            <section id="view-applicants-container">
+                <section id="job-details-container">
+                    <span className="view-applicants-job-details">
+                        <h3>Job Title: </h3>
+                        <p>{jobTitle}</p>
+                    </span>
+                    <span className="view-applicants-job-details">
+                        <h3>Total Applicants: </h3>
+                        <p><strong>{totalApplicants}</strong></p>
+                    </span>
+                    <span className="view-applicants-job-details">
+                        <h3>Posting Published on: </h3>
+                        <p>{formatDate(publishedAt)}</p>
+                    </span>
+                    
+                </section>
 
+                <section id="applicants-container">
+                    {
+                        applicantDetails.map((p) => {
+                            return(
+                                <Row key={p.id} name={p.name} id={p.id}/>
+                            )
+                        })
+                    }
+                </section>
+            </section>
         </>
     )
 }

--- a/client/src/components/company-portal/ViewApplicantsForm.jsx
+++ b/client/src/components/company-portal/ViewApplicantsForm.jsx
@@ -55,15 +55,15 @@ function ViewApplicantsForm({ posting }){
             <section id="view-applicants-container">
                 <section id="job-details-container">
                     <span className="view-applicants-job-details">
-                        <h3>Job Title: </h3>
+                        <h3>Job Title:</h3>
                         <p>{jobTitle}</p>
                     </span>
                     <span className="view-applicants-job-details">
-                        <h3>Total Applicants: </h3>
+                        <h3>Total Applicants:</h3>
                         <p><strong>{totalApplicants}</strong></p>
                     </span>
                     <span className="view-applicants-job-details">
-                        <h3>Posting Published on: </h3>
+                        <h3>Posting Published:</h3>
                         <p>{formatDate(publishedAt)}</p>
                     </span>
                 </section>

--- a/client/src/components/company-portal/ViewApplicantsForm.jsx
+++ b/client/src/components/company-portal/ViewApplicantsForm.jsx
@@ -4,6 +4,7 @@ import { applicantApi } from "../../utils/api";
 import Row from "../common/Row.jsx";
 
 function ViewApplicantsForm({ posting }){
+    const [postingId, setPostingId] = useState("");
     const [publishedAt, setPublishedAt] = useState("");
     const [jobTitle, setJobTitle] = useState("");
     const [totalApplicants, setTotalApplicants] = useState("");
@@ -12,6 +13,7 @@ function ViewApplicantsForm({ posting }){
 
     useEffect(() => {
         if(!posting) return;
+        setPostingId(posting._id);
         setPublishedAt(posting.publishedAt);
         setJobTitle(posting.title);
         setTotalApplicants(posting.applicants.length);
@@ -23,12 +25,24 @@ function ViewApplicantsForm({ posting }){
             let applicants = []
             for(let i = 0; i < jobApplicantIds.length; i++){
                 const details = await applicantApi.getById(jobApplicantIds[i]);
-                console.log(details); // REMOVE ME
+
+                const applicantAppliedTo = details.jobsAppliedTo;
+                
+                let appliedDate = "";
+                for(let j = 0; j < applicantAppliedTo.length; j++){
+                    let posting = applicantAppliedTo[j].job;
+                    if(posting === postingId){
+                        appliedDate = applicantAppliedTo[j].appliedAt;
+                        break;
+                    }
+                }
+                
                 applicants.push({
                     id: details._id,
                     name: details.name,
                     status: details.status,
-                    email: details.email
+                    email: details.email,
+                    date: appliedDate
                 });
             }
             setApplicantDetails(applicants);
@@ -57,7 +71,7 @@ function ViewApplicantsForm({ posting }){
                     {
                         applicantDetails.map((p) => {
                             return(
-                                <Row key={p.id} name={p.name} id={p.id} email={p.email} status={p.status}/>
+                                <Row key={p.id} name={p.name} id={p.id} email={p.email} status={p.status} date={p.date}/>
                             )
                         })
                     }

--- a/client/src/components/company-portal/ViewApplicantsForm.jsx
+++ b/client/src/components/company-portal/ViewApplicantsForm.jsx
@@ -4,7 +4,6 @@ import { applicantApi } from "../../utils/api";
 import Row from "../common/Row.jsx";
 
 function ViewApplicantsForm({ posting }){
-    const [companyId, setCompanyId] = useState("");
     const [publishedAt, setPublishedAt] = useState("");
     const [jobTitle, setJobTitle] = useState("");
     const [totalApplicants, setTotalApplicants] = useState("");
@@ -13,7 +12,6 @@ function ViewApplicantsForm({ posting }){
 
     useEffect(() => {
         if(!posting) return;
-        setCompanyId(posting._id);
         setPublishedAt(posting.publishedAt);
         setJobTitle(posting.title);
         setTotalApplicants(posting.applicants.length);
@@ -27,7 +25,9 @@ function ViewApplicantsForm({ posting }){
                 const details = await applicantApi.getById(jobApplicantIds[i]);
                 applicants.push({
                     id: details._id,
-                    name: details.name
+                    name: details.name,
+                    status: details.status,
+                    email: details.email
                 });
             }
             setApplicantDetails(applicants);
@@ -35,7 +35,6 @@ function ViewApplicantsForm({ posting }){
         getApplicantDetails();
     }, [jobApplicantIds]);
     
-
     return(
         <>
             <section id="view-applicants-container">
@@ -52,14 +51,12 @@ function ViewApplicantsForm({ posting }){
                         <h3>Posting Published on: </h3>
                         <p>{formatDate(publishedAt)}</p>
                     </span>
-                    
                 </section>
-
                 <section id="applicants-container">
                     {
                         applicantDetails.map((p) => {
                             return(
-                                <Row key={p.id} name={p.name} id={p.id}/>
+                                <Row key={p.id} name={p.name} id={p.id} email={p.email} status={p.status}/>
                             )
                         })
                     }
@@ -68,5 +65,4 @@ function ViewApplicantsForm({ posting }){
         </>
     )
 }
-
 export default ViewApplicantsForm;

--- a/client/src/components/company-portal/ViewResumeForm.jsx
+++ b/client/src/components/company-portal/ViewResumeForm.jsx
@@ -9,7 +9,7 @@ function ViewResumeForm({ applicantId }){
 
     useEffect(() => {
         setId(applicantId);
-    }, [])
+    }, []);
 
     function handleChange (e) {
         setSelectedViewing(e.target.value);

--- a/client/src/components/company-portal/ViewResumeForm.jsx
+++ b/client/src/components/company-portal/ViewResumeForm.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import "../profile-page/ResumeOptionsForm.css"
+import { applicantApi } from "../../utils/api.js";
+
+function ViewResumeForm({ applicantId }){
+    const [selectedViewing, setSelectedViewing] = useState("");
+    const [resumeErrorMessage, setResumeErrorMessage] = useState("");
+    const [id, setId] = useState("");
+
+    useEffect(() => {
+        setId(applicantId);
+    }, [])
+
+    function handleChange (e) {
+        setSelectedViewing(e.target.value);
+    }
+
+    async function displayResume(e){
+        e.preventDefault();
+        let url = ""
+        if(selectedViewing === "browser"){
+            url = applicantApi.getResumeViewUrl(id);
+        }else if(selectedViewing === "download"){
+            url = applicantApi.getResumeUrl(id);
+        }else{
+            setResumeErrorMessage("No Option Selected");
+            return;
+        }
+
+        try {
+            const response = await fetch(url);
+            if(response.status === 404){
+                setResumeErrorMessage("Applicant Has no Resume");
+                return;
+            }
+            window.open(url, "_blank");
+        } catch (error) {
+            setResumeErrorMessage("Error Ocurred Retrieving Resume");
+        }
+    }
+
+    return (
+        <>
+            <div id="resume-question-container">
+                <h3>Resume Viewing Choice:</h3>
+                <div id="radio-buttons-section">
+                    <div className="radio-container">
+                        <label className="resume-radio">
+                            <input
+                                className="resume-radio-options"
+                                type="radio"
+                                name="browser"
+                                value="browser"
+                                checked={selectedViewing === "browser"}
+                                onChange={handleChange}
+                            /> In Browser
+                        </label>
+                    </div>
+                    <div className="radio-container">
+                        <label className="resume-radio">
+                            <input
+                                className="resume-radio-options"
+                                type="radio"
+                                name="download"
+                                value="download"
+                                checked={selectedViewing === "download"}
+                                onChange={handleChange}
+                            /> Download
+                        </label>
+                    </div>
+                </div>
+                <p id="error-text">{resumeErrorMessage}</p>
+                <button id="resume-choice" type="submit" onClick={displayResume}>
+                    Submit
+                </button>
+            </div>
+        </>
+    )
+}
+
+export default ViewResumeForm;

--- a/client/src/components/profile-page/EditProfileForm.css
+++ b/client/src/components/profile-page/EditProfileForm.css
@@ -11,6 +11,9 @@
         color: antiquewhite;
         cursor: pointer;
     }
+    button:hover{
+        background-color: var(--color-cta-secondary);
+    }
     label {
         font-size: 0.75em;
     }

--- a/client/src/components/profile-page/Profile.css
+++ b/client/src/components/profile-page/Profile.css
@@ -54,19 +54,19 @@ button {
 }
 
 #upload-resume{
-    background-color: var(--color-cta-secondary);
-}
-
-#upload-resume:hover{
-    background-color: var(--color-cta-secondary-darker);
-}
-
-#upload-profile-picture{
     background-color: var(--color-cta-primary);
 }
 
-#upload-profile-picture:hover{
+#upload-resume:hover{
     background-color: var(--color-cta-secondary);
+}
+
+#upload-profile-picture{
+    background-color: var(--color-cta-secondary);
+}
+
+#upload-profile-picture:hover{
+    background-color: var(--color-cta-secondary-darker);
 }
 
 #download-resume{

--- a/client/src/components/profile-page/Profile.jsx
+++ b/client/src/components/profile-page/Profile.jsx
@@ -197,16 +197,16 @@ function ProfilePage () {
                 </section> 
             : "" }
 
-            <Modal isOpen={uploadResume} onClose={() => setUploadResume(false)} title={"Upload Resume"} size={"small"}>
+            <Modal isOpen={uploadResume} onClose={() => setUploadResume(false)} title={"Resume"} size={"small"}>
                 <UploadResumeForm />
             </Modal>
-            <Modal isOpen={editProfile} onClose={() => setEditProfile(false)} title={"Edit Profile"}>
+            <Modal isOpen={editProfile} onClose={() => setEditProfile(false)} title={"Edit"}>
                 <EditProfileForm />
             </Modal>
-            <Modal isOpen={uploadPfp} onClose={() => setUploadPfp(false)} title={"Edit Profile Picture"} size={"small"}>
+            <Modal isOpen={uploadPfp} onClose={() => setUploadPfp(false)} title={"Picture"} size={"small"}>
                 <UploadPfpForm />
             </Modal>
-            <Modal isOpen={resumeOptions} onClose={() => setResumeOptions(false)} title={"Resume Viewing Options"} size={"small"}>
+            <Modal isOpen={resumeOptions} onClose={() => setResumeOptions(false)} title={"Viewing"} size={"small"}>
                 <ResumeOptionsForm />
             </Modal>
         </>

--- a/client/src/components/profile-page/Profile.jsx
+++ b/client/src/components/profile-page/Profile.jsx
@@ -48,7 +48,13 @@ function ProfilePage () {
                     const fetchApplicanInfo = await applicantApi.getById(id);
                     setEnrolledName(fetchApplicanInfo.name);
                     setEmail(fetchApplicanInfo.email);
-                    setJobsAppliedTo(fetchApplicanInfo.jobsAppliedTo);
+
+                    let applicationIds = [];
+                    const jobApplications = fetchApplicanInfo.jobsAppliedTo;
+                    for(let i = 0; i < jobApplications.length; i++){
+                        applicationIds.push(jobApplications[i].job);
+                    }
+                    setJobsAppliedTo(applicationIds);
                     break;
                 case "company":
                     const fetchCompanyInfo = await companyApi.getById(id);
@@ -158,13 +164,13 @@ function ProfilePage () {
                         <button id="edit-profile" onClick={() => setEditProfile(true)}>
                             Edit Profile
                         </button>
+                        <button id="upload-profile-picture" onClick={() => setUploadPfp(true)}>
+                            Upload Profile Picture
+                        </button>
                         {role === "applicant" ?
                             <>
                                 <button id="upload-resume" onClick={() => setUploadResume(true)}>
                                     Upload Resume
-                                </button>
-                                <button id="upload-profile-picture" onClick={() => setUploadPfp(true)}>
-                                    Upload Profile Picture
                                 </button>
                                 <button id="download-resume" onClick={() => setResumeOptions(true)}>
                                     View Resume

--- a/client/src/components/profile-page/ResumeOptionsForm.css
+++ b/client/src/components/profile-page/ResumeOptionsForm.css
@@ -13,6 +13,11 @@
     font-size: 1.10em;
 }
 
+#resume-choice:hover{
+    background-color: var(--color-cta-secondary);
+    margin-bottom: 1.1em;
+}
+
 .resume-radio {
     font-size: 1.25em;
 }

--- a/client/src/components/profile-page/ResumeOptionsForm.jsx
+++ b/client/src/components/profile-page/ResumeOptionsForm.jsx
@@ -55,7 +55,7 @@ function ResumeOptionsForm(){
     return (
         <>
             <div id="resume-question-container">
-                <h3>Resume Viewing Choice:</h3>
+                <h3>Resume Viewing:</h3>
                 <div id="radio-buttons-section">
                     <div className="radio-container">
                         <label className="resume-radio">

--- a/client/src/components/profile-page/UploadPfpForm.css
+++ b/client/src/components/profile-page/UploadPfpForm.css
@@ -19,7 +19,11 @@
 #submit-pfp {
     margin: 2em 0 2em 0;
     padding: 0.5em 1em 0.5em 1em;
-    background-color: var(--color-cta-primary);
+    background-color: var(--color-cta-secondary-darker);
     color: white;
     font-size: 1.10em;
+}
+
+#submit-pfp:hover{
+    background-color: var(--color-body);
 }

--- a/client/src/components/profile-page/UploadPfpForm.css
+++ b/client/src/components/profile-page/UploadPfpForm.css
@@ -19,7 +19,7 @@
 #submit-pfp {
     margin: 2em 0 2em 0;
     padding: 0.5em 1em 0.5em 1em;
-    background-color: var(--color-title-alt);
+    background-color: var(--color-cta-primary);
     color: white;
     font-size: 1.10em;
 }

--- a/client/src/components/profile-page/UploadPfpForm.jsx
+++ b/client/src/components/profile-page/UploadPfpForm.jsx
@@ -51,7 +51,7 @@ function UploadPfpForm(){
         <>
             <div id="upload-pfp-form">
                 <form id="pfp-form" onSubmit={submitPfp}>
-                    <h3>Please Upload Profile Picture Below:</h3>
+                    <h3>Upload Profile Picture Below:</h3>
                     <br />
                     <input 
                         type="file" 

--- a/client/src/components/profile-page/UploadResumeForm.css
+++ b/client/src/components/profile-page/UploadResumeForm.css
@@ -19,7 +19,11 @@
 #submit-resume {
     margin: 2em 0 2em 0;
     padding: 0.5em 1em 0.5em 1em;
-    background-color: var(--color-title-alt);
+    background-color: var(--color-cta-secondary-darker);
     color: white;
     font-size: 1.10em;
+}
+
+#submit-resume:hover{
+    background-color: var(--color-body);
 }

--- a/client/src/components/profile-page/UploadResumeForm.jsx
+++ b/client/src/components/profile-page/UploadResumeForm.jsx
@@ -36,7 +36,7 @@ function UploadResumeForm(){
         <>
             <div id="upload-resume-form">
                 <form id="resume-form" onSubmit={submitResume}>
-                    <h3>Please Upload Resume Below:</h3>
+                    <h3>Upload Resume Below:</h3>
                     <br />
                     <input 
                         type="file" 

--- a/server/repository/jobPosting.repository.js
+++ b/server/repository/jobPosting.repository.js
@@ -73,12 +73,13 @@ const jobPostingRepository = {
   },
 
   async addApplicantToJob(jobId, applicantId) {
+    const date = new Date();
     const job = await JobPosting.findById(jobId).lean();
     if (!job) return null;
     const alreadyApplied = (job.applicants || []).some((id) => id.toString() === String(applicantId));
     if (alreadyApplied) return { job, alreadyApplied: true };
     await JobPosting.findByIdAndUpdate(jobId, { $addToSet: { applicants: applicantId } });
-    await Applicant.findByIdAndUpdate(applicantId, { $addToSet: { jobsAppliedTo: jobId } });
+    await Applicant.findByIdAndUpdate(applicantId, { $addToSet: { jobsAppliedTo: { job: jobId, appliedAt: date } } });
     return { job: await JobPosting.findById(jobId).lean(), alreadyApplied: false };
   },
 

--- a/server/repository/models/applicant.model.js
+++ b/server/repository/models/applicant.model.js
@@ -11,7 +11,11 @@ const applicantSchema = new mongoose.Schema({
   pfpContentType: { type: String, default: 'image/jpeg' },
   resume: { type: Buffer },
   resumeContentType: { type: String, default: 'application/pdf' },
-  jobsAppliedTo: [{ type: mongoose.Schema.Types.ObjectId, ref: 'JobPosting' }],
+  jobsAppliedTo: [{
+    _id: false,
+    job: {type: mongoose.Schema.Types.ObjectId, ref: 'JobPosting', required: true},
+    appliedAt: {type: Date, default: Date.now},
+  }],
 }, { timestamps: true });
 
 applicantSchema.plugin(passwordHashPlugin);

--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -96,11 +96,11 @@ async function seed() {
   await JobPosting.findByIdAndUpdate(jobPostings[11]._id, { applicants: [] });
 
   // set jobsAppliedTo on applicants
-  await Applicant.findByIdAndUpdate(applicants[0]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: now}, {job: jobPostings[1]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[7]._id, appliedAt: now}, {job: jobPostings[9]._id, appliedAt: now}]});
-  await Applicant.findByIdAndUpdate(applicants[1]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: now}, {job: jobPostings[1]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[6]._id, appliedAt: now}, {job: jobPostings[9]._id, appliedAt: now}]});
-  await Applicant.findByIdAndUpdate(applicants[2]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[7]._id, appliedAt: now}, {job: jobPostings[10]._id, appliedAt: now}]});
-  await Applicant.findByIdAndUpdate(applicants[3]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[6]._id, appliedAt: now}, {job: jobPostings[8]._id, appliedAt: now}, {job: jobPostings[9]._id, appliedAt: now}]});
-  await Applicant.findByIdAndUpdate(applicants[4]._id, { jobsAppliedTo: [{job: jobPostings[2]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[7]._id, appliedAt: now}]});
+  await Applicant.findByIdAndUpdate(applicants[0]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: daysAgo(4)}, {job: jobPostings[1]._id, appliedAt: daysAgo(8)}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[7]._id, appliedAt: daysAgo(21)}, {job: jobPostings[9]._id, appliedAt: daysAgo(1)}]});
+  await Applicant.findByIdAndUpdate(applicants[1]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: daysAgo(7)}, {job: jobPostings[1]._id, appliedAt: daysAgo(9)}, {job: jobPostings[4]._id, appliedAt: daysAgo(2)}, {job: jobPostings[6]._id, appliedAt: daysAgo(14)}, {job: jobPostings[9]._id, appliedAt: daysAgo(2)}]});
+  await Applicant.findByIdAndUpdate(applicants[2]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: daysAgo(10)}, {job: jobPostings[7]._id, appliedAt: daysAgo(3)}, {job: jobPostings[10]._id, appliedAt: daysAgo(13)}]});
+  await Applicant.findByIdAndUpdate(applicants[3]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: daysAgo(3)}, {job: jobPostings[4]._id, appliedAt: daysAgo(15)}, {job: jobPostings[6]._id, appliedAt: daysAgo(8)}, {job: jobPostings[8]._id, appliedAt: daysAgo(6)}, {job: jobPostings[9]._id, appliedAt: now}]});
+  await Applicant.findByIdAndUpdate(applicants[4]._id, { jobsAppliedTo: [{job: jobPostings[2]._id, appliedAt: daysAgo(10)}, {job: jobPostings[4]._id, appliedAt: daysAgo(2)}, {job: jobPostings[7]._id, appliedAt: daysAgo(1)}]});
 
   // create an admin
   await Administrator.create({

--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -96,11 +96,11 @@ async function seed() {
   await JobPosting.findByIdAndUpdate(jobPostings[11]._id, { applicants: [] });
 
   // set jobsAppliedTo on applicants
-  await Applicant.findByIdAndUpdate(applicants[0]._id, { jobsAppliedTo: [jobPostings[0]._id, jobPostings[1]._id, jobPostings[4]._id, jobPostings[7]._id, jobPostings[9]._id] });
-  await Applicant.findByIdAndUpdate(applicants[1]._id, { jobsAppliedTo: [jobPostings[0]._id, jobPostings[1]._id, jobPostings[4]._id, jobPostings[6]._id, jobPostings[9]._id] });
-  await Applicant.findByIdAndUpdate(applicants[2]._id, { jobsAppliedTo: [jobPostings[0]._id, jobPostings[4]._id, jobPostings[7]._id, jobPostings[10]._id] });
-  await Applicant.findByIdAndUpdate(applicants[3]._id, { jobsAppliedTo: [jobPostings[0]._id, jobPostings[4]._id, jobPostings[6]._id, jobPostings[8]._id, jobPostings[9]._id] });
-  await Applicant.findByIdAndUpdate(applicants[4]._id, { jobsAppliedTo: [jobPostings[2]._id, jobPostings[4]._id, jobPostings[7]._id] });
+  await Applicant.findByIdAndUpdate(applicants[0]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: now}, {job: jobPostings[1]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[7]._id, appliedAt: now}, {job: jobPostings[9]._id, appliedAt: now}]});
+  await Applicant.findByIdAndUpdate(applicants[1]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: now}, {job: jobPostings[1]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[6]._id, appliedAt: now}, {job: jobPostings[9]._id, appliedAt: now}]});
+  await Applicant.findByIdAndUpdate(applicants[2]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[7]._id, appliedAt: now}, {job: jobPostings[10]._id, appliedAt: now}]});
+  await Applicant.findByIdAndUpdate(applicants[3]._id, { jobsAppliedTo: [{job: jobPostings[0]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[6]._id, appliedAt: now}, {job: jobPostings[8]._id, appliedAt: now}, {job: jobPostings[9]._id, appliedAt: now}]});
+  await Applicant.findByIdAndUpdate(applicants[4]._id, { jobsAppliedTo: [{job: jobPostings[2]._id, appliedAt: now}, {job: jobPostings[4]._id, appliedAt: now}, {job: jobPostings[7]._id, appliedAt: now}]});
 
   // create an admin
   await Administrator.create({


### PR DESCRIPTION
## Overview
Companies are now able to view their posting applicants from the company portal. This can be done by clicking on a "Applicants" through a specific posting. The popup display the applicant, including their pfp, name, email, status, applied date, and the option to view their resume. **NOTE** that, even though seeding applies applicants to a job, they don't have resume. The view resume form has error handling to deal with default users who have applied to jobs without a resume.

The backend schema has been updated to include the date when an applicant applies for a job. This resulted in some issues displaying an applicant's applied to jobs in profile which has been fixed.

##

Closes #101 #129 #130 

##

#### Profile Page
- Updated CSS aspects of forms on profile page (button hover, modal title too long).
- Resolved issue of displaying applied to jobs after schema update.
- Resolved issue of small modal titles clipping the 'X' button.
- Admins and Companies can upload pfp from profile page now.

#### Company Portal Page
- Added modal for showing applicants.
- Modal shows details on jobs, and applicant information with the ability to view the respective users resume.
- Resolved issues with posting "edit" button being off-centered and the wrong color.

### Server Side
- Updated applicant model to hold both the job posting id and the time the applicant applied at.
- Updated jobPosting repo to handle appliedAt attribute along with posting id.
- Updated seed.js to have default applicants applied to postings also have a timestamp.