### PR TITLE
Fix Overflow on Comments

### DIFF
--- a/client/src/components/home/Comment.jsx
+++ b/client/src/components/home/Comment.jsx
@@ -69,7 +69,7 @@ export default function Comment({ comment, currentUserId, role, isFromJobOwner, 
                     </div>
                 </div>
             ) : (
-                <p>{comment.content}</p>
+                <p className="comment-body">{comment.content}</p>
             )}
         </div>
     );

--- a/client/src/components/home/Home.css
+++ b/client/src/components/home/Home.css
@@ -368,6 +368,13 @@
     background-color: rgba(123, 74, 46, 0.08);
 }
 
+.comment-body {
+    margin: 12px 0 12px 0;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 .job-details-comments-list {
     overflow-y: auto;
     flex: 1;


### PR DESCRIPTION
Added CSS to fix the overflow on comments when viewing a job posting on the Home page:

<img width="752" height="335" alt="image" src="https://github.com/user-attachments/assets/68af7281-776a-4362-ad85-809fe373fefc" />

#131 