### PR TITLE
Frontend Testing - part 3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.suggestOnTriggerCharacters": false,
+    "terminal.integrated.suggest.suggestOnTriggerCharacters": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "editor.suggestOnTriggerCharacters": false,
-    "terminal.integrated.suggest.suggestOnTriggerCharacters": false
-}

--- a/client/src/components/admin/Analytics/__tests__/Analytics.test.jsx
+++ b/client/src/components/admin/Analytics/__tests__/Analytics.test.jsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import Analytics from '../Analytics.jsx'
+import { adminApi } from '../../../../utils/api'
+
+jest.mock('../../../../utils/api', () => ({
+    adminApi: { getAllCompanyAnalytics: jest.fn() },
+}))
+
+jest.mock('../JobPostings.jsx', () => ({
+    __esModule: true,
+    default: ({ numJobPostings }) => (
+        <div data-testid="job-postings">JobPostings {numJobPostings}</div>
+    ),
+}))
+
+jest.mock('../NumberOfUsers.jsx', () => ({
+    __esModule: true,
+    default: ({ numUsers }) => (
+        <div data-testid="num-users">NumberOfUsers {numUsers}</div>
+    ),
+}))
+
+jest.mock('../JobFillRate.jsx', () => ({
+    __esModule: true,
+    default: ({ jobFillRate }) => (
+        <div data-testid="fill-rate">JobFillRate {jobFillRate.join(',')}</div>
+    ),
+}))
+
+const fakeAnalytics = {
+    numJobPostings: 7,
+    numUsers: 42,
+    jobPostingsByDate: [{ date: '2026-01-01', count: 1 }],
+    allAccountsByDate: [{ date: '2026-01-01', count: 2 }],
+    adminAccountsByDate: [],
+    companyAccountsByDate: [],
+    applicantAccountsByDate: [],
+    filledJobs: 3,
+    unfilledJobs: 4,
+}
+
+describe('Analytics', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        adminApi.getAllCompanyAnalytics.mockResolvedValue(fakeAnalytics)
+    })
+
+    test('fetches analytics once', async () => {
+        render(<Analytics whichAnalyticsData="jobPostings" />)
+
+        await waitFor(() => {
+            expect(adminApi.getAllCompanyAnalytics).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    test('renders JobPostings when whichAnalyticsData=jobPostings', async () => {
+        render(<Analytics whichAnalyticsData="jobPostings" />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('job-postings')).toHaveTextContent('JobPostings 7')
+        })
+        expect(screen.queryByTestId('num-users')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('fill-rate')).not.toBeInTheDocument()
+    })
+
+    test('renders NumberOfUsers when whichAnalyticsData=numUsers', async () => {
+        render(<Analytics whichAnalyticsData="numUsers" />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('num-users')).toHaveTextContent('NumberOfUsers 42')
+        })
+        expect(screen.queryByTestId('job-postings')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('fill-rate')).not.toBeInTheDocument()
+    })
+
+    test('renders JobFillRate when whichAnalyticsData=jobFillRate', async () => {
+        render(<Analytics whichAnalyticsData="jobFillRate" />)
+
+        await waitFor(() => {
+            expect(screen.getByTestId('fill-rate')).toHaveTextContent('JobFillRate 3,4')
+        })
+        expect(screen.queryByTestId('job-postings')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('num-users')).not.toBeInTheDocument()
+    })
+})

--- a/client/src/components/admin/Analytics/__tests__/BarChart.test.jsx
+++ b/client/src/components/admin/Analytics/__tests__/BarChart.test.jsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import BarChart from '../AnalyticsCharts/BarChart.jsx'
+
+const mockBar = jest.fn(() => null)
+
+jest.mock('react-chartjs-2', () => ({
+    Bar: (props) => mockBar(props),
+}))
+
+describe('BarChart', () => {
+    beforeEach(() => {
+        mockBar.mockClear()
+    })
+
+    test('passes sorted labels and datasets to Bar', () => {
+        const data = {
+            jobPostingsByDate: [
+                { date: '2026-01-02', count: 5 },
+                { date: '2026-01-01', count: 2 },
+            ],
+        }
+        const xAxisLabels = [
+            { date: '2026-01-02' },
+            { date: '2026-01-01' },
+        ]
+
+        render(
+            <BarChart barTitle="Job Postings" data={data} xAxisLabels={xAxisLabels} dataNames={['Job Postings Created']} />
+        )
+
+        expect(mockBar).toHaveBeenCalledTimes(1)
+        const { data: passedData, options } = mockBar.mock.calls[0][0]
+
+        expect(passedData.labels).toEqual(['2026-01-01', '2026-01-02'])
+        expect(passedData.datasets[0].label).toBe('Job Postings Created')
+        expect(passedData.datasets[0].data).toEqual([2, 5])
+    })
+
+    test('fills missing dates with 0', () => {
+        const data = {
+            jobPostingsByDate: [
+                { date: '2026-01-02', count: 5 },
+            ],
+        }
+        const xAxisLabels = [{ date: '2026-01-01' }, { date: '2026-01-02' }]
+
+        render(
+            <BarChart barTitle="Job Postings" data={data} xAxisLabels={xAxisLabels} dataNames={['Job Postings Created']} />
+        )
+
+        const { data: passedData } = mockBar.mock.calls[0][0]
+        expect(passedData.labels).toEqual(['2026-01-01', '2026-01-02'])
+        expect(passedData.datasets[0].data).toEqual([0, 5])
+    })
+
+    test('hides all but first dataset when multiple series provided', () => {
+        const data = {
+            numUsersByDate: [{ date: '2026-01-01', count: 2 }],
+            adminAccountsByDate: [{ date: '2026-01-01', count: 1 }],
+        }
+        const xAxisLabels = [{ date: '2026-01-01' }]
+
+        render(
+            <BarChart barTitle="Users" data={data} xAxisLabels={xAxisLabels} dataNames={['All', 'Admins']} />
+        )
+
+        const { data: passedData } = mockBar.mock.calls[0][0]
+        expect(passedData.datasets).toHaveLength(2)
+        expect(passedData.datasets[0].hidden).toBe(false)
+        expect(passedData.datasets[1].hidden).toBe(true)
+    })
+})

--- a/client/src/components/admin/Analytics/__tests__/JobFillRate.test.jsx
+++ b/client/src/components/admin/Analytics/__tests__/JobFillRate.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import JobFillRate from '../JobFillRate.jsx'
+
+jest.mock('../AnalyticsCharts/PieChart.jsx', () => ({
+    __esModule: true,
+    default: ({ pieChartTitle, chartData, chartLabels }) => (
+        <div data-testid="pie">
+            {pieChartTitle} | {chartData.join(',')} | {chartLabels.join(',')}
+        </div>
+    ),
+}))
+
+test('renders pie chart with title, labels, and data', () => {
+    render(<JobFillRate jobFillRate={[3, 4]} />)
+    expect(screen.getByTestId('pie')).toHaveTextContent('Job Posting Fill Rate')
+    expect(screen.getByTestId('pie')).toHaveTextContent('3,4')
+    expect(screen.getByTestId('pie')).toHaveTextContent('Filled Closed Job Posting')
+    expect(screen.getByTestId('pie')).toHaveTextContent('Unfilled Closed Job Posting')
+})

--- a/client/src/components/admin/Analytics/__tests__/JobPostings.test.jsx
+++ b/client/src/components/admin/Analytics/__tests__/JobPostings.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import JobPostings from '../JobPostings.jsx'
+
+jest.mock('../AnalyticsCharts/BarChart.jsx', () => ({
+    __esModule: true,
+    default: ({ barTitle, xAxisLabels, dataNames }) => (
+        <div data-testid="bar">
+            {barTitle} | labels:{xAxisLabels.length} | names:{dataNames.join(',')}
+        </div>
+    ),
+}))
+
+test('renders stat card and bar chart props', () => {
+    const jobPostingsByDate = { jobPostingsByDate: [{ date: '2026-01-01', count: 2 }] }
+    
+    render(<JobPostings jobPostingsByDate={jobPostingsByDate} numJobPostings={7} />)
+
+    expect(screen.getByText('Total Job Postings')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+    expect(screen.getByTestId('bar')).toHaveTextContent('Job Postings')
+    expect(screen.getByTestId('bar')).toHaveTextContent('Job Postings Created')
+})

--- a/client/src/components/admin/Analytics/__tests__/NumberOfUsers.test.jsx
+++ b/client/src/components/admin/Analytics/__tests__/NumberOfUsers.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import NumberOfUsers from '../NumberOfUsers.jsx'
+
+jest.mock('../AnalyticsCharts/BarChart.jsx', () => ({
+    __esModule: true,
+    default: ({ barTitle, xAxisLabels, dataNames }) => (
+        <div data-testid="bar">
+            {barTitle} | labels:{xAxisLabels.length} | names:{dataNames.join(',')}
+        </div>
+    ),
+}))
+
+test('renders stat card and bar chart with series names', () => {
+    const usersByDate = {
+        numUsersByDate: [{ date: '2026-01-01', count: 2 }],
+        adminAccountsByDate: [],
+        companyAccountsByDate: [],
+        applicantAccountsByDate: [],
+    }
+
+    render(<NumberOfUsers usersByDate={usersByDate} numUsers={42} />)
+
+    expect(screen.getByText('Total Users')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+    expect(screen.getByTestId('bar')).toHaveTextContent('Number of Users')
+    expect(screen.getByTestId('bar')).toHaveTextContent('Number of All Users')
+    expect(screen.getByTestId('bar')).toHaveTextContent('Admin Accounts')
+    expect(screen.getByTestId('bar')).toHaveTextContent('Company Accounts')
+    expect(screen.getByTestId('bar')).toHaveTextContent('Applicant Accounts')
+})

--- a/client/src/components/admin/Analytics/__tests__/PieChart.test.jsx
+++ b/client/src/components/admin/Analytics/__tests__/PieChart.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import PieChart from '../AnalyticsCharts/PieChart.jsx'
+
+const mockPie = jest.fn(() => null)
+
+jest.mock('react-chartjs-2', () => ({
+    Pie: (props) => mockPie(props),
+}))
+
+describe('PieChart', () => {
+    beforeEach(() => {
+        mockPie.mockClear()
+    })
+
+    test('passes labels, data, and title to Pie', () => {
+        render(
+            <PieChart pieChartTitle="Fill Rate" chartData={[3, 1]} chartLabels={['Filled', 'Unfilled']} chartBackgroundColor={['green', 'red']} />
+        )
+
+        expect(mockPie).toHaveBeenCalledTimes(1)
+        const { data, options } = mockPie.mock.calls[0][0]
+
+        expect(data.labels).toEqual(['Filled', 'Unfilled'])
+        expect(data.datasets[0].data).toEqual([3, 1])
+        expect(data.datasets[0].backgroundColor).toEqual(['green', 'red'])
+    })
+
+    test('datalabels formatter returns percent and handles total = 0', () => {
+        render(
+            <PieChart pieChartTitle="Fill Rate" chartData={[0, 0]} chartLabels={['A', 'B']} chartBackgroundColor={['a', 'b']} />
+        )
+
+        const { options } = mockPie.mock.calls[0][0]
+        const formatter = options.plugins.datalabels.formatter
+
+        // total = 0
+        const ctxZero = { chart: { data: { datasets: [{ data: [0, 0] }] } } }
+        expect(formatter(0, ctxZero)).toBe('0%')
+
+        // normal percent (3/4 * 100 = 75%)
+        const ctx = { chart: { data: { datasets: [{ data: [3, 1] }] } } }
+        expect(formatter(3, ctx)).toBe('75.0%')
+    })
+})

--- a/client/src/components/admin/Analytics/__tests__/StatCard.test.jsx
+++ b/client/src/components/admin/Analytics/__tests__/StatCard.test.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import StatCard from '../StatCard.jsx'
+
+test('renders label and value', () => {
+    render(<StatCard label="Total Users" value={42} />)
+    expect(screen.getByText('Total Users')).toBeInTheDocument()
+    expect(screen.getByText('42')).toBeInTheDocument()
+})

--- a/client/src/components/admin/__tests__/AdminDropDown.test.jsx
+++ b/client/src/components/admin/__tests__/AdminDropDown.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import AdminDropDown from '../AdminDropDown.jsx'
+
+function setup() {
+    const setPage = jest.fn()
+    const setWhichAnalyticsData = jest.fn()
+    const setFilterType = jest.fn()
+
+    render(
+        <AdminDropDown setPage={setPage} setWhichAnalyticsData={setWhichAnalyticsData} setFilterType={setFilterType} />
+    )
+    return {setPage, setWhichAnalyticsData, setFilterType}
+}
+
+test('FIns Users sets page and filter type', () => {
+    const { setPage, setWhichAnalyticsData, setFilterType } = setup()
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Find Users' } })
+    expect(setPage).toHaveBeenCalledWith('Find Users')
+    expect(setWhichAnalyticsData).not.toHaveBeenCalled()
+    expect(setFilterType).toHaveBeenCalledWith('name')
+})
+
+test('New Admin only sets page', () => {
+    const { setPage, setFilterType } = setup()
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'New Admin' } })
+    expect(setPage).toHaveBeenCalledWith('New Admin')
+    expect(setFilterType).not.toHaveBeenCalled()
+})
+
+test('Analytics sets page and default analytics page', () => {
+    const { setPage, setWhichAnalyticsData } = setup()
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Analytics' } })
+    expect(setPage).toHaveBeenCalledWith('Analytics')
+    expect(setWhichAnalyticsData).toHaveBeenCalledWith('jobPostings')
+})

--- a/client/src/components/admin/__tests__/AdminHandler.test.jsx
+++ b/client/src/components/admin/__tests__/AdminHandler.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import AdminHandler from '../AdminHandler.jsx'
+
+jest.mock('../FindUsers', () => ({
+    __esModule: true,
+    default: function MockFindUsers(props) {
+        const { useEffect } = require('react')
+        useEffect(() => {
+            props.setLoading(false)
+        }, [props.setLoading])
+        return <div data-testid="mock-find-users">Mock FindUsers</div>
+    },
+}))
+
+jest.mock('../CreateNewAdminForm', () => ({
+    __esModule: true,
+    default: () => <div data-testid="mock-new-admin">Mock CreateNewAdminForm</div>
+}))
+
+jest.mock('../Analytics/Analytics', () => ({
+    __esModule: true,
+    default: ({ whichAnalyticsData }) => (
+        <div data-testid="mock-analytics">{whichAnalyticsData}</div>
+    )
+}))
+
+function getMainPageSelect() {
+    return screen.getAllByRole('combobox')[0] // should be the right select?
+}
+
+describe('AdminHandler', () => {
+    test('starts on Find Users, after load it shows FindUserSearch and FindUsers', async () => {
+        render(<AdminHandler />)
+        expect(screen.getByRole('heading', { name: 'Admin Portal' })).toBeInTheDocument()
+        expect(screen.getByTestId('mock-find-users')).toBeInTheDocument()
+
+        await waitFor(() => {
+            expect(screen.getByText('Search By:')).toBeInTheDocument() // in FindUserSearch
+        })
+    })
+
+    test('switching to New Admin shows CreateNewAdminForm and hides FindUsers', async () => {
+        render(<AdminHandler />)
+        await waitFor(() => expect(screen.getByText('Search By:')).toBeInTheDocument()) // in FindUserSearch
+
+        fireEvent.change(getMainPageSelect(), { target: { value: 'New Admin' } })
+        
+        expect(screen.queryByTestId('mock-find-users')).not.toBeInTheDocument()
+        expect(screen.getByTestId('mock-new-admin')).toBeInTheDocument()
+    })
+
+    test('Analytics page shows data selector and Analytics with default jobPostings state', async () => {
+        render(<AdminHandler />)
+        await waitFor(() => expect(screen.getByText('Search By:')).toBeInTheDocument())
+
+        fireEvent.change(getMainPageSelect(), { target: { value: 'Analytics' } })
+
+        expect(screen.getByText('Select Analytics Data:')).toBeInTheDocument()
+        expect(screen.getByTestId('mock-analytics')).toHaveTextContent('jobPostings')
+    })
+
+    test('Analytics sleect updated whichAnalyticsData is passed to Analytics', async () => {
+        render(<AdminHandler />)
+        await waitFor(() => expect(screen.getByText('Search By:')).toBeInTheDocument())
+
+        fireEvent.change(getMainPageSelect(), { target: { value: 'Analytics' } }) // setting to Analytics page
+        
+        const analyticsSelect = screen.getAllByRole('combobox')[1]
+        
+        fireEvent.change(analyticsSelect, { target: { value: 'numUsers' } })
+        expect(screen.getByTestId('mock-analytics')).toHaveTextContent('numUsers')
+    })
+})

--- a/client/src/components/admin/__tests__/CreateNewAdminForm.test.jsx
+++ b/client/src/components/admin/__tests__/CreateNewAdminForm.test.jsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import CreateNewAdminForm from '../CreateNewAdminForm.jsx'
+import { authApi } from '../../../utils/api'
+
+jest.mock('../../../utils/api', () => ({
+    authApi: {register: jest.fn()}
+}))
+
+const TEST_PW = 'Abcdef1234'
+
+function fillMatchingPasswords() {
+    fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: TEST_PW } })
+    fireEvent.change(screen.getByPlaceholderText('Confirm Password'), { target: { value: TEST_PW } })
+}
+
+describe('CreateNewAdminForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        authApi.register.mockResolvedValue({ok: true})
+    })
+
+    test('does not call register when all fields are empty', () => {
+        render(<CreateNewAdminForm />)
+        fireEvent.click(screen.getByRole('button', { name: /create new admin/i }))
+        expect(authApi.register).not.toHaveBeenCalled()
+    })
+
+    test('shows Full name is required when name is empty and does not submit', async () => {
+        render(<CreateNewAdminForm />)
+        fillMatchingPasswords()
+        fireEvent.click(screen.getByRole('button', { name: /create new admin/i }))
+
+        await waitFor(() => {
+            expect(screen.getByText('Full name is required')).toBeInTheDocument()
+        })
+        expect(authApi.register).not.toHaveBeenCalled()
+    })
+
+    test('shows Email is required when email is empty and does not submit', async () => {
+        render(<CreateNewAdminForm />)
+        fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'Jane Admin' } })
+        fillMatchingPasswords()
+        fireEvent.click(screen.getByRole('button', { name: /create new admin/i }))
+
+        await waitFor(() => {
+            expect(screen.getByText('Email is required')).toBeInTheDocument()
+        })
+        expect(authApi.register).not.toHaveBeenCalled()
+    })
+
+    test('submits admin payload and shows success message', async () => {
+        render(<CreateNewAdminForm />)
+        fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'Hans Zimmer' } })
+        fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'hans@music.com' } })
+        fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: TEST_PW } })
+        fireEvent.change(screen.getByPlaceholderText('Confirm Password'), { target: { value: TEST_PW } })
+        
+        fireEvent.click(screen.getByRole('button', { name: /create new admin/i }))
+        
+        await waitFor(() => {
+            expect(authApi.register).toHaveBeenCalledWith({
+                role: 'administrator',
+                email: 'hans@music.com',
+                password: TEST_PW,
+                name: 'Hans Zimmer',
+            })
+        })
+
+        expect(screen.getByText('New admin created successfully!')).toBeInTheDocument()
+    })
+
+    test('success message clears after 2 seconds', async () => {
+        jest.useFakeTimers()
+        render(<CreateNewAdminForm />)
+
+        fireEvent.change(screen.getByPlaceholderText('Username'), { target: { value: 'Hans Zimmer' } })
+        fireEvent.change(screen.getByPlaceholderText('Email'), { target: { value: 'hans@music.com' } })
+        fireEvent.change(screen.getByPlaceholderText('Password'), { target: { value: TEST_PW } })
+        fireEvent.change(screen.getByPlaceholderText('Confirm Password'), { target: { value: TEST_PW } })
+        fireEvent.click(screen.getByRole('button', { name: /create new admin/i }))
+
+        await waitFor(() => {
+            expect(screen.getByText('New admin created successfully!')).toBeInTheDocument()
+        })
+    })
+})

--- a/client/src/components/admin/__tests__/EditAdmin.test.jsx
+++ b/client/src/components/admin/__tests__/EditAdmin.test.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import EditAdmin from '../EditAdmin.jsx'
+import { adminApi } from '../../../utils/api'
+
+jest.mock('../../../utils/api', () => ({
+    adminApi: { editUser: jest.fn() },
+}))
+
+function setup(overrides = {}) {
+    const props = {
+        setXButton: jest.fn(),
+        userDetails: {
+            id: 't1',
+            name: 'Howard Shore',
+            email: 'howard@music.com',
+            type: 'admin',
+        },
+        allCards: [],
+        setAllCards: jest.fn(),
+        setFilteredCards: jest.fn(),
+        ...overrides,
+    }
+
+    render(<EditAdmin {...props} />)
+    return props
+}
+
+describe('EditAdmin', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        adminApi.editUser.mockResolvedValue({ok: true})
+    })
+
+    test('clicking X calls setXButton', () => {
+        const s = setup()
+        fireEvent.click(screen.getByText('X'))
+        expect(s.setXButton).toHaveBeenCalledTimes(1)
+    })
+
+    test('submitting valid values calls adminApi.editUser w payload', async () => {
+        setup()
+        fireEvent.change(screen.getByDisplayValue('Howard Shore'), { target: { value: 'Howard Shore' } })
+        fireEvent.change(screen.getByDisplayValue('howard@music.com'), { target: { value: 'howard@music.com' } })
+        
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
+        
+        await waitFor(() => {
+            expect(adminApi.editUser).toHaveBeenCalledWith('t1', {
+                role: 'admin',
+                name: 'Howard Shore',
+                email: 'howard@music.com',
+                password: '',
+            })
+        })
+    })
+
+    test('does not call API when validation fails', async () => {
+        setup()
+
+        fireEvent.change(screen.getByDisplayValue('Howard Shore'), { target: { value: '' } })
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
+        await waitFor(() => {
+            expect(screen.getByText(/required|enter first and last name/i)).toBeInTheDocument()
+        })
+
+        expect(adminApi.editUser).not.toHaveBeenCalled()
+    })
+
+})

--- a/client/src/components/admin/__tests__/FindUserSearch.test.jsx
+++ b/client/src/components/admin/__tests__/FindUserSearch.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import FindUserSearch from '../FindUserSearch.jsx'
+
+function setup() {
+    const setFilter = jest.fn()
+    const setFilterType = jest.fn()
+    render(<FindUserSearch setFilter={setFilter} setFilterType={setFilterType} />)
+    return { setFilter, setFilterType }
+}
+
+describe('FindUserSearch', () => {
+    test('renders the search controls', () => {
+        setup()
+        expect(screen.getByText('Search By:')).toBeInTheDocument()
+        expect(screen.getByRole('combobox')).toBeInTheDocument()
+        expect(screen.getByPlaceholderText('...')).toBeInTheDocument()
+    })
+
+    test('changing filter type calls setFilterType', () => {
+        const s = setup()
+        fireEvent.change(screen.getByRole('combobox'), { target: { value: 'type' } })
+        expect(s.setFilterType).toHaveBeenCalledWith('type')
+    })
+
+    test('typing in search input calls setFilter', () => {
+        const s = setup()
+        fireEvent.change(screen.getByPlaceholderText('...'), { target: { value: 'alice' } })
+        expect(s.setFilter).toHaveBeenCalledWith('alice')
+    })
+})

--- a/client/src/components/admin/__tests__/FindUsers.test.jsx
+++ b/client/src/components/admin/__tests__/FindUsers.test.jsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import FindUsers from '../FindUsers.jsx'
+import { adminApi, applicantApi, companyApi, getAuthUser } from '../../../utils/api'
+
+jest.mock('../../../utils/api', () => ({
+    adminApi: { getAllAdmins: jest.fn(), changeUserStatus: jest.fn(), deleteAdmin: jest.fn() },
+    applicantApi: { getAll: jest.fn(), deleteAccount: jest.fn() },
+    companyApi: {getAll: jest.fn(), deleteAccount: jest.fn() },
+    getAuthUser: jest.fn()
+}))
+
+function setup(overrides = {}) {
+    const { loading: initialLoading = true, setLoading: _omit, ...restOverrides } = overrides
+    const props = {
+        filterType: 'name',
+        filter: '',
+        ...restOverrides,
+    }
+
+    function Wrapper() {
+        const [loading, setLoading] = React.useState(initialLoading)
+        return <FindUsers {...props} loading={loading} setLoading={setLoading} />
+    }
+
+    render(<Wrapper />)
+    return props
+}
+
+describe('FindUsers', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        getAuthUser.mockReturnValue({ _id: 'self' })
+        
+        applicantApi.getAll.mockResolvedValue([
+            { _id: 'self', name: 'Me User', email: 'me@example.com', status: 'active' },
+            { _id: 'a1', name: 'Frodo Baggins', email: 'baggins@lotr.com', status: 'active' },
+        ])
+        companyApi.getAll.mockResolvedValue([
+            { _id: 'c1', name: 'The Shire', email: 'shire@lotr.com', status: 'inactive'},
+        ])
+        adminApi.getAllAdmins.mockResolvedValue([
+            { _id: 'ad1', name: 'Gandalf Mithrandir', email: 'gandalf@lotr.com', status: 'active'},
+        ])
+    })
+
+    test('shows loading then renders users (exlcudes authenticated user)', async () => {
+        setup()
+        expect(screen.getByText(/loading/i)).toBeInTheDocument()
+
+        await waitFor(() => {
+            expect(screen.queryByText(/loading/i)).not.toBeInTheDocument()
+        })
+
+        expect(screen.queryByText('Me User')).not.toBeInTheDocument()
+        expect(screen.queryByText('Frodo Baggins')).toBeInTheDocument()
+        expect(screen.queryByText('The Shire')).toBeInTheDocument()
+        expect(screen.queryByText('Gandalf Mithrandir')).toBeInTheDocument()
+    })
+
+    test('changing a user status calls adminApi.changeUserStatus', async () => {
+        setup()
+        await waitFor(() => {
+            expect(screen.getByText('Frodo Baggins')).toBeInTheDocument()
+        })
+
+        const card = screen.getByText('Frodo Baggins').closest('section')
+        const statusSelect = within(card).getByRole('combobox')
+        fireEvent.change(statusSelect, { target: { value: 'inactive' } })
+        
+        await waitFor(() => {
+            expect(adminApi.changeUserStatus).toHaveBeenCalledWith('applicant', 'a1', 'inactive')
+        })
+    })
+
+    test('deleting a company user calls companyApi.deleteAccount', async () => {
+        setup()
+
+        await waitFor(() => {
+            expect(screen.getByText('The Shire')).toBeInTheDocument()
+        })
+
+        const card = screen.getByText('The Shire').closest('section')
+        const delete_btn = within(card).getByRole('button', { name: /delete/i })
+        fireEvent.click(delete_btn)
+
+        await waitFor(() => {
+            expect(companyApi.deleteAccount).toHaveBeenCalledWith('c1')
+        })
+    })
+
+    test('shows empty state when filter removes all users', async () => {
+        setup({ filterType: 'name', filter: 'bruh' })
+        
+        await waitFor(() => {
+            expect(screen.getByText(/no users match/i)).toBeInTheDocument()
+        })
+    })
+})
+
+

--- a/client/src/components/admin/__tests__/UserCard.test.jsx
+++ b/client/src/components/admin/__tests__/UserCard.test.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import UserCard from '../UserCard.jsx'
+
+function setup(overrides = {}) {
+    const props = {
+        id: 'u1',
+        name: 'Katniss Everdeen',
+        type: 'applicant',
+        status: 'active',
+        email: 'katniss@example.com',
+        deleteUser: jest.fn(),
+        xButtonSwitch: jest.fn(),
+        setEditAccountInfo: jest.fn(),
+        updateStatus: jest.fn(),
+        ...overrides,
+    }
+
+    render(<UserCard {...props} />)
+    return props
+}
+
+describe('UserCard', () => {
+    test('renders name, type, and email', () => {
+        setup()
+        expect(screen.getByText('Katniss Everdeen')).toBeInTheDocument()
+        expect(screen.getByText('Type: applicant')).toBeInTheDocument()
+        expect(screen.getByText('Email: katniss@example.com')).toBeInTheDocument()
+    })
+
+    test('changing status calls updateStatus(id, type, newStatus)', () => {
+        const s = setup({ status: 'active' })
+        const card = screen.getByText('Katniss Everdeen').closest('section')
+        const select = within(card).getByRole('combobox')
+
+        fireEvent.change(select, { target: { value: 'inactive' } })
+
+        expect(s.updateStatus).toHaveBeenCalledWith('u1', 'applicant', 'inactive')
+    })
+
+    test('clicking Edit sets edit info and toggles modal', () => {
+        const s = setup()
+        fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+        expect(s.setEditAccountInfo).toHaveBeenCalledWith({
+            id: 'u1',
+            name: 'Katniss Everdeen',
+            type: 'applicant',
+            email: 'katniss@example.com',
+        })
+        expect(s.xButtonSwitch).toHaveBeenCalledTimes(1)
+    })
+
+    test('clicking Delete calls deleteUser', () => {
+        const s = setup()
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+        expect(s.deleteUser).toHaveBeenCalledWith('u1', 'applicant')
+    })
+})

--- a/client/src/components/auth/__tests__/ChooseRegisterType.test.jsx
+++ b/client/src/components/auth/__tests__/ChooseRegisterType.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import ChooseRegisterType from '../register/ChooseRegisterType.jsx'
+
+jest.mock('../ChooseUserTypeFlow.jsx', () => ({
+    __esModule: true,
+    default: function MockFlow({ titleText, bottomButton, footer }) {
+        return (
+            <div>
+                <h2>{titleText}</h2>
+                {bottomButton}
+                {typeof footer === 'function' ? footer(() => { }) : footer}
+            </div>
+        )
+    },
+}))
+
+test('uses register title and login link', () => {
+    render(
+        <MemoryRouter initialEntries={['/register']}>
+            <ChooseRegisterType />
+        </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: /registering as an/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: /already have an account/i})).toHaveAttribute('href', '/Login')
+})

--- a/client/src/components/auth/__tests__/ChooseUserTypeFlow.test.jsx
+++ b/client/src/components/auth/__tests__/ChooseUserTypeFlow.test.jsx
@@ -12,7 +12,7 @@ function setup(overrides = {}) {
             renderNext={renderNext}
             bottomButton={<span>Bottom</span>}
             footer={(selectAdmin) => (
-                <button type="button" onClick={selectedAdmin}>
+                <button type="button" onClick={selectAdmin}>
                     Admin entry
                 </button>
             )}
@@ -24,7 +24,7 @@ function setup(overrides = {}) {
 
 test('shows title, figures, and bottom; back calls onBack', () => {
     const { onBack } = setup();
-    expect(screen.getByRole('heading', { name: 'Test title' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Test Title' })).toBeInTheDocument()
     expect(screen.getByText('Bottom')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('img', { name: /back button/i }))
@@ -32,17 +32,17 @@ test('shows title, figures, and bottom; back calls onBack', () => {
 })
 
 test('Applicant advances to next screen with type Applicant', () => {
-    setup()
-    const employer_figure = screen.getByText('Applicant').closest('figure')
-    fireEvent.click(within(employer_figure).getByRole('img'))
-    expect(screen.getByTestId('next-screen')).toHaveTextConent('Applicant')
+    const { renderNext } = setup()
+    const applicantFigure = screen.getByText('Applicant').closest('figure')
+    fireEvent.click(within(applicantFigure).getByRole('img'))
+    expect(screen.getByTestId('next-screen')).toHaveTextContent('Applicant')
     expect(renderNext).toHaveBeenCalled()
 })
 
 test('Employer advances to next screen with type Employer', () => {
     setup()
-    const employer_figure = screen.getByText('Employer').closest('figure')
-    fireEvent.click(within(employer_figure).getByRole('img'))
+    const employerFigure = screen.getByText('Employer').closest('figure')
+    fireEvent.click(within(employerFigure).getByRole('img'))
     expect(screen.getByTestId('next-screen')).toHaveTextContent('Employer')
 })
 

--- a/client/src/components/auth/__tests__/ChooseUserTypeFlow.test.jsx
+++ b/client/src/components/auth/__tests__/ChooseUserTypeFlow.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import ChooseUserTypeFlow from '../ChooseUserTypeFlow.jsx'
+
+function setup(overrides = {}) {
+    const onBack = jest.fn()
+    const renderNext = jest.fn((type) => <div data-testid="next-screen">{type}</div>)
+    render(
+        <ChooseUserTypeFlow
+            titleText="Test Title"
+            onBack={onBack}
+            renderNext={renderNext}
+            bottomButton={<span>Bottom</span>}
+            footer={(selectAdmin) => (
+                <button type="button" onClick={selectedAdmin}>
+                    Admin entry
+                </button>
+            )}
+            {...overrides}
+        />
+    )
+    return {onBack, renderNext}
+}
+
+test('shows title, figures, and bottom; back calls onBack', () => {
+    const { onBack } = setup();
+    expect(screen.getByRole('heading', { name: 'Test title' })).toBeInTheDocument()
+    expect(screen.getByText('Bottom')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('img', { name: /back button/i }))
+    expect(onBack).toHaveBeenCalled()
+})
+
+test('Applicant advances to next screen with type Applicant', () => {
+    setup()
+    const employer_figure = screen.getByText('Applicant').closest('figure')
+    fireEvent.click(within(employer_figure).getByRole('img'))
+    expect(screen.getByTestId('next-screen')).toHaveTextConent('Applicant')
+    expect(renderNext).toHaveBeenCalled()
+})
+
+test('Employer advances to next screen with type Employer', () => {
+    setup()
+    const employer_figure = screen.getByText('Employer').closest('figure')
+    fireEvent.click(within(employer_figure).getByRole('img'))
+    expect(screen.getByTestId('next-screen')).toHaveTextContent('Employer')
+})
+
+test('footer admin control advances with type Admin', () => {
+    setup()
+    fireEvent.click(screen.getByRole('button', { name: 'Admin entry' }))
+    expect(screen.getByTestId('next-screen')).toHaveTextContent('Admin')
+})

--- a/client/src/components/auth/__tests__/ChoseLoginType.test.jsx
+++ b/client/src/components/auth/__tests__/ChoseLoginType.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import ChoseLoginType from '../login/ChoseLoginType.jsx'
+
+jest.mock('../ChooseUserTypeFlow.jsx', () => ({
+    __esModule: true,
+    default: function MockFlow({ titleText, bottomButton, footer }) {
+        return (
+            <div>
+                <h2>{titleText}</h2>
+                {bottomButton}
+                {typeof footer === 'function' ? footer(() => { }) : footer}
+            </div>
+        )
+    },
+}))
+
+test('uses login title and register link', () => {
+    render(
+        <MemoryRouter initialEntries={['/Login']}>
+            <ChoseLoginType />
+        </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: /logging in as an/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: /don't have an account/i})).toHaveAttribute('href', '/register')
+})

--- a/client/src/components/company-portal/__tests__/CloseStatus.test.jsx
+++ b/client/src/components/company-portal/__tests__/CloseStatus.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import CloseStatus from '../CloseStatus.jsx'
+
+jest.mock('../../common/Modal.jsx', () => ({
+    __esModule: true,
+    default: ({ isOpen, children, title }) => (isOpen ? <div><div>{title}</div>{children}</div> : null),
+}))
+
+test('Close Posting disabled until reason selected, then calls onClosePosting', async () => {
+    const onClosePosting = jest.fn().mockResolvedValue({})
+    const onClose = jest.fn()
+
+    render(
+        <CloseStatus postingToClose={{ _id: 'p1', title: 'Role' }} onClose={onClose} onClosePosting={onClosePosting} />
+    )
+
+    const closeBtn = screen.getByRole('button', { name: /close posting/i })
+    expect(closeBtn).toBeDisabled()
+
+    fireEvent.click(screen.getByLabelText(/position was filled/i))
+    expect(closeBtn).not.toBeDisabled()
+
+    fireEvent.click(closeBtn)
+    expect(onClosePosting).toHaveBeenCalledWith('p1', 'FILLED')
+})

--- a/client/src/components/company-portal/__tests__/CompanyPortal.test.jsx
+++ b/client/src/components/company-portal/__tests__/CompanyPortal.test.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import CompanyPortal from '../CompanyPortal.jsx'
+
+function renderWithRouter(ui, { initialEntries = ['/'] } = {}) {
+    return render(
+        <MemoryRouter initialEntries={initialEntries}>
+            <Routes>
+                <Route path="/" element={ui} />
+                <Route path="/profile" element={<div data-testid="profile-route">Profile</div>} />
+            </Routes>
+        </MemoryRouter>
+    )
+}
+
+jest.mock('../CompanyPortalJobPostings.jsx', () => ({
+    __esModule: true,
+    default: () => <div data-testid="job-postings" />,
+}))
+
+jest.mock('../CreateJobForm.jsx', () => ({
+    __esModule: true,
+    default: () => <div data-testid="create-job-form" />,
+}))
+
+jest.mock('../../common/Modal.jsx', () => ({
+    __esModule: true,
+    default: ({ isOpen, title, children }) =>
+        isOpen ? (
+            <div data-testid="modal">
+                <div>{title}</div>
+                {children}
+            </div>
+        ) : null,
+}))
+
+describe('CompanyPortal', () => {
+    beforeEach(() => {
+        localStorage.setItem('jobly_user', JSON.stringify({ _id: 'c1', name: 'P&P' }))
+    })
+
+    afterEach(() => localStorage.clear())
+
+    test('profile button navigates to /profile', () => {
+        renderWithRouter(<CompanyPortal />)
+        fireEvent.click(screen.getByRole('button', { name: /company profile/i }))
+        expect(screen.getByTestId('profile-route')).toBeInTheDocument()
+    })
+
+    test('create button opens modal', () => {
+        renderWithRouter(<CompanyPortal />)
+
+        expect(screen.queryByTestId('modal')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: /create new job posting/i }))
+        expect(screen.getByTestId('modal')).toBeInTheDocument()
+        expect(screen.getByTestId('create-job-form')).toBeInTheDocument()
+    })
+})

--- a/client/src/components/company-portal/__tests__/CompanyPortalJobPostings.test.jsx
+++ b/client/src/components/company-portal/__tests__/CompanyPortalJobPostings.test.jsx
@@ -11,13 +11,13 @@ jest.mock('../../../utils/api.js', () => ({
 
 jest.mock('../../common/Card.jsx', () => ({
     __esModule: true,
-    default: ({ title, children, footer }) => {
+    default: ({ title, children, footer }) => (
         <section data-testid="card">
             <h3>{title}</h3>
             <div>{children}</div>
             <div>{footer}</div>
         </section>
-    },
+    ),
 }))
 
 jest.mock('../../common/Modal.jsx', () => ({
@@ -69,7 +69,7 @@ describe('CompanyPortalJobPostings', () => {
         renderView({ companyId: 'c1', companyName: 'Narnia', refreshKey: 0 })
 
         await waitFor(() => {
-            expect(screen.getByText(/no job postings for acme/i)).toBeInTheDocument()
+            expect(screen.getByText(/no job postings for Narnia/i)).toBeInTheDocument()
         })
     })
 
@@ -111,7 +111,7 @@ describe('CompanyPortalJobPostings', () => {
         renderView({ companyId: 'c1', companyName: 'Narnia', refreshKey: 0 })
         await waitFor(() => expect(screen.getByText('Coding')).toBeInTheDocument())
 
-        const card = screen.getByText('Engineer').closest('[data-testid="card"]')
+        const card = screen.getByText('Coding').closest('[data-testid="card"]')
         const statusSelect = within(card).getByRole('combobox')
 
         fireEvent.change(statusSelect, { target: { value: 'UNPUBLISHED' } })

--- a/client/src/components/company-portal/__tests__/CompanyPortalJobPostings.test.jsx
+++ b/client/src/components/company-portal/__tests__/CompanyPortalJobPostings.test.jsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import CompanyPortalJobPostings from '../CompanyPortalJobPostings.jsx'
+import { companyApi, jobPostingApi } from '../../../utils/api.js'
+
+jest.mock('../../../utils/api.js', () => ({
+    companyApi: { getJobPostings: jest.fn() },
+    jobPostingApi: {updateStatus: jest.fn()},
+}))
+
+jest.mock('../../common/Card.jsx', () => ({
+    __esModule: true,
+    default: ({ title, children, footer }) => {
+        <section data-testid="card">
+            <h3>{title}</h3>
+            <div>{children}</div>
+            <div>{footer}</div>
+        </section>
+    },
+}))
+
+jest.mock('../../common/Modal.jsx', () => ({
+    __esModule: true,
+    default: ({ isOpen, children, title }) => isOpen ? (
+            <div data-testid="modal">
+                <div>{title}</div>
+                {children}
+            </div>
+        ) : null,
+}))
+
+jest.mock('../EditJobForm.jsx', () => ({
+    __esModule: true,
+    default: () => <div data-testid="edit-form" />
+}))
+
+jest.mock('../ViewApplicantsForm.jsx', () => ({
+    __esModule: true,
+    default: () => <div data-testid="view-applicants" />,
+}))
+
+jest.mock('../CloseStatus.jsx', () => ({
+    __esModule: true,
+    default: () => null,
+}))
+
+function renderView(props) {
+    return render(
+        <MemoryRouter>
+            <CompanyPortalJobPostings {...props} />
+        </MemoryRouter>
+    )
+}
+
+describe('CompanyPortalJobPostings', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('shows missing company id when companyId absent', () => {
+        renderView({ companyId: null, companyName: 'Narnia', refreshKey: 0 })
+        expect(screen.getByText(/missing company id/i)).toBeInTheDocument()
+    })
+
+    test('shows no postings message when API returns empty list', async () => {
+        companyApi.getJobPostings.mockResolvedValue([])
+
+        renderView({ companyId: 'c1', companyName: 'Narnia', refreshKey: 0 })
+
+        await waitFor(() => {
+            expect(screen.getByText(/no job postings for acme/i)).toBeInTheDocument()
+        })
+    })
+
+    test('renders postings and company header', async () => {
+        companyApi.getJobPostings.mockResolvedValue([
+            {
+                _id: 'p1',
+                title: 'Coding',
+                location: 'Remote',
+                description: 'Build things fr',
+                status: 'ACTIVE',
+            },
+        ])
+
+        renderView({ companyId: 'c1', companyName: 'Narnia', refreshKey: 0 })
+
+        await waitFor(() => {
+            expect(screen.getByText("Narnia's Current Postings")).toBeInTheDocument()
+        })
+
+        expect(screen.getByText('Coding')).toBeInTheDocument()
+        expect(screen.getByText(/location/i)).toBeInTheDocument()
+        expect(screen.getByText(/description/i)).toBeInTheDocument()
+    })
+
+    test('changing status calls jobPostingApi.updateStatus', async () => {
+        companyApi.getJobPostings.mockResolvedValue([
+            {
+                _id: 'p1',
+                title: 'Coding',
+                location: 'Remote',
+                description: 'Build things fr',
+                status: 'ACTIVE',
+            },
+        ])
+
+        jobPostingApi.updateStatus.mockResolvedValue({ ok: true })
+
+        renderView({ companyId: 'c1', companyName: 'Narnia', refreshKey: 0 })
+        await waitFor(() => expect(screen.getByText('Coding')).toBeInTheDocument())
+
+        const card = screen.getByText('Engineer').closest('[data-testid="card"]')
+        const statusSelect = within(card).getByRole('combobox')
+
+        fireEvent.change(statusSelect, { target: { value: 'UNPUBLISHED' } })
+
+        await waitFor(() => {
+            expect(jobPostingApi.updateStatus).toHaveBeenCalledWith('p1', 'UNPUBLISHED', undefined)
+        })
+    })
+})

--- a/client/src/components/company-portal/__tests__/CompanyPortalSubNav.test.jsx
+++ b/client/src/components/company-portal/__tests__/CompanyPortalSubNav.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import CompanyPortalSubNav from '../CompanyPortalSubNav.jsx'
+
+test('buttons call handlers', () => {
+    const onPostingsClick = jest.fn()
+    const onCreateClick = jest.fn()
+    const onProfileClick = jest.fn()
+
+    render(
+        <CompanyPortalSubNav onPostingsClick={onPostingsClick} onCreateClick={onCreateClick} onProfileClick={onProfileClick} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /company job postings/i }))
+    fireEvent.click(screen.getByRole('button', { name: /create new job posting/i }))
+    fireEvent.click(screen.getByRole('button', { name: /company profile/i }))
+
+    expect(onPostingsClick).toHaveBeenCalledTimes(1)
+    expect(onCreateClick).toHaveBeenCalledTimes(1)
+    expect(onProfileClick).toHaveBeenCalledTimes(1)
+})

--- a/client/src/components/company-portal/__tests__/CreateJobForm.test.jsx
+++ b/client/src/components/company-portal/__tests__/CreateJobForm.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import CreateJobForm from '../CreateJobForm.jsx'
+import { jobPostingApi } from '../../../utils/api.js'
+
+jest.mock('../../../utils/api.js', () => ({
+    jobPostingApi: { createJobPosting: jest.fn() },
+}))
+
+jest.mock('../JobPostingForm.jsx', () => ({
+    __esModule: true,
+    default: ({ submitLabel, onSubmit }) => (
+        <div>
+            <button onClick={() => onSubmit({ title: 'T', location: 'L', description: 'D' })}>
+                {submitLabel}
+            </button>
+        </div>
+    ),
+}))
+
+test('creates job posting and calls onSuccess', async () => {
+    jobPostingApi.createJobPosting.mockResolvedValue({ ok: true })
+    const onSuccess = jest.fn()
+
+    render(<CreateJobForm companyId="c1" onSuccess={onSuccess} onCancel={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => {
+        expect(jobPostingApi.createJobPosting).toHaveBeenCalledWith('c1', {
+            title: 'T',
+            location: 'L',
+            description: 'D',
+        })
+        expect(onSuccess).toHaveBeenCalled()
+    })
+})

--- a/client/src/components/company-portal/__tests__/EditJobForm.test.jsx
+++ b/client/src/components/company-portal/__tests__/EditJobForm.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import EditJobForm from '../EditJobForm.jsx'
+import { jobPostingApi } from '../../../utils/api.js'
+
+jest.mock('../../../utils/api.js', () => ({
+    jobPostingApi: { update: jest.fn() },
+}))
+
+jest.mock('../JobPostingForm.jsx', () => ({
+    __esModule: true,
+    default: ({ onSubmit }) => (
+        <button onClick={() => onSubmit({ title: 'T', location: 'L', description: 'D', status: 'ACTIVE', tags: [] })}>
+            Update
+        </button>
+    ),
+}))
+
+test('updates job posting and calls onSuccess with payload', async () => {
+    jobPostingApi.update.mockResolvedValue({ ok: true })
+    const onSuccess = jest.fn()
+
+    render(
+        <EditJobForm posting={{ _id: 'p1', title: 'Old', status: 'ACTIVE' }} onClosePosting={jest.fn()} onSuccess={onSuccess} onCancel={jest.fn()} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+
+    const payload = { title: 'T', location: 'L', description: 'D', status: 'ACTIVE', tags: [] }
+
+    await waitFor(() => {
+        expect(jobPostingApi.update).toHaveBeenCalledWith('p1', expect.objectContaining(payload))
+        expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining(payload))
+    })
+})

--- a/client/src/components/company-portal/__tests__/JobPostingForm.test.jsx
+++ b/client/src/components/company-portal/__tests__/JobPostingForm.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import JobPostingForm from '../JobPostingForm.jsx'
+import { validateCreateJobForm } from '../../../utils/validation/validateCreateJobForm.js'
+
+jest.mock('../../../utils/validation/validateCreateJobForm.js', () => ({
+    validateCreateJobForm: jest.fn(),
+}))
+
+describe('JobPostingForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('blocks submit on validation errors', async () => {
+        validateCreateJobForm.mockReturnValue({ title: 'Title required' })
+        const onSubmit = jest.fn()
+
+        render(<JobPostingForm onSubmit={onSubmit} onCancel={jest.fn()} />)
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        expect(onSubmit).not.toHaveBeenCalled()
+        expect(screen.getByText('Title required')).toBeInTheDocument()
+    })
+
+    test('submits with tags parsed when showTagsField is true', async () => {
+        validateCreateJobForm.mockReturnValue({})
+        const onSubmit = jest.fn().mockResolvedValue({})
+        render(<JobPostingForm onSubmit={onSubmit} showTagsField={true} />)
+
+        fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'coding' } })
+        fireEvent.change(screen.getByPlaceholderText('Location'), { target: { value: 'Remote' } })
+        fireEvent.change(screen.getByPlaceholderText('Description'), { target: { value: 'Desc' } })
+        fireEvent.change(screen.getByPlaceholderText(/react, javascript/i), { target: { value: ' React,  ,Remote  ' } })
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith({
+                title: 'coding',
+                location: 'Remote',
+                description: 'Desc',
+                tags: ['React', 'Remote'],
+            })
+        })
+    })
+
+    test('cancel calls onCancel', () => {
+        const onCancel = jest.fn()
+        render(<JobPostingForm onCancel={onCancel} />)
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+        expect(onCancel).toHaveBeenCalled()
+    })
+})

--- a/client/src/components/company-portal/__tests__/ViewApplicantsForm.test.jsx
+++ b/client/src/components/company-portal/__tests__/ViewApplicantsForm.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import ViewApplicantsForm from '../ViewApplicantsForm.jsx'
+import { applicantApi } from '../../../utils/api'
+import { formatDate } from '../../../utils/formatHelpers.js'
+
+jest.mock('../../../utils/api', () => ({
+    applicantApi: { getById: jest.fn() },
+}))
+
+jest.mock('../../../utils/formatHelpers.js', () => ({
+    formatDate: jest.fn(),
+}))
+
+jest.mock('../../common/Row.jsx', () => ({
+    __esModule: true,
+    default: ({ name, email }) => <div data-testid="row">{name} {email}</div>,
+}))
+
+test('renders posting details and applicant rows', async () => {
+    formatDate.mockReturnValue('Jan 1')
+    applicantApi.getById
+        .mockResolvedValueOnce({
+            _id: 'a1', name: 'Jane', status: 'active', email: 'jane@pp.com',
+            jobsAppliedTo: [{ job: 'p1', appliedAt: '2026-01-01' }],
+        })
+        .mockResolvedValueOnce({
+            _id: 'a2', name: 'Elizabeth', status: 'active', email: 'elizabeth@pp.com',
+            jobsAppliedTo: [{ job: 'p1', appliedAt: '2026-01-02' }],
+        })
+
+    render(
+        <ViewApplicantsForm
+            posting={{ _id: 'p1', title: 't_title', publishedAt: '2026-01-01', applicants: ['a1', 'a2'] }}
+        />
+    )
+
+    expect(screen.getByText('t_title')).toBeInTheDocument()
+    expect(screen.getByText('Jan 1')).toBeInTheDocument()
+
+    await waitFor(() => {
+        expect(screen.getAllByTestId('row')).toHaveLength(2)
+    })
+})

--- a/client/src/components/company-portal/__tests__/ViewResumeForm.test.jsx
+++ b/client/src/components/company-portal/__tests__/ViewResumeForm.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ViewResumeForm from '../ViewResumeForm.jsx'
+import { applicantApi } from '../../../utils/api.js'
+
+jest.mock('../../../utils/api.js', () => ({
+    applicantApi: {
+        getResumeUrl: jest.fn(),
+        getResumeViewUrl: jest.fn(),
+    },
+}))
+
+describe('ViewResumeForm', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        global.fetch = jest.fn()
+        window.open = jest.fn()
+    })
+
+    test('shows error if no option selected', async () => {
+        render(<ViewResumeForm applicantId="a1" />)
+        fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+        expect(screen.getByText('No Option Selected')).toBeInTheDocument()
+    })
+
+    test('404 shows Applicant Has no Resume', async () => {
+        applicantApi.getResumeViewUrl.mockReturnValue('http://bruh/view')
+        fetch.mockResolvedValue({ status: 404 })
+
+        render(<ViewResumeForm applicantId="a1" />)
+        fireEvent.click(screen.getByLabelText(/in browser/i))
+        fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+        await waitFor(() => {
+            expect(screen.getByText('Applicant Has no Resume')).toBeInTheDocument()
+        })
+        expect(window.open).not.toHaveBeenCalled()
+    })
+
+    test('success opens window', async () => {
+        applicantApi.getResumeUrl.mockReturnValue('http://bruh/download')
+        fetch.mockResolvedValue({ status: 200 })
+
+        render(<ViewResumeForm applicantId="a1" />)
+        fireEvent.click(screen.getByLabelText(/download/i))
+        fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+
+        await waitFor(() => {
+            expect(window.open).toHaveBeenCalledWith('http://bruh/download', '_blank')
+        })
+    })
+})


### PR DESCRIPTION
Implements more frontend tests. 

Unit tests cover the core user flows for auth/user type selection, admin portal, and the company portal. The tests prioritize main functionality and wiring between components with a few edge cases (form validation, API error handling, and empty-states).

**Files**
- User type flow / auth UI - BackButton, ChooseFigure, ChooseUserTypeFLow, ChoseLoginType, ChooseRegisterTYpe)
- Auth forms - LoginFOrm, RegisterForm
- Admin portal - AdminDropDown, AdminHandler, FindUsers, FindUserSearch, UserCard, CreateNewAdminForm, EditAdmin
- Analytics on admin page - all files in Analytics folders
- Company portal - CompanyPortal, CompanyPortalSubNav, COmpanyPortalJobPostings, CreateJobForm, EditJobForm, JobPostingForm, CloseStatus, ViewresumeForm, ViewApplicantsForm


Closes:
#144  
#143 
#146 
#147 

The only frontend tests left are the profile page, common UI, and Utils components. Then all the backend tests need to be written/implemented. These will be done in separate PRs.