### PR TITLE
Added Job Posting view/edit/delete to admins

### DIFF
--- a/client/src/components/admin/AdminDropDown.jsx
+++ b/client/src/components/admin/AdminDropDown.jsx
@@ -1,4 +1,4 @@
-export default function AdminDropDown({setPage, setWhichAnalyticsData, setFilterType}){
+export default function AdminDropDown({setPage, setWhichAnalyticsData, setFilterType, pageToView}){
     const changePage = (e=>{
         if(e.target.value === "Find Users" ){
             setPage("Find Users");
@@ -15,7 +15,7 @@ export default function AdminDropDown({setPage, setWhichAnalyticsData, setFilter
     });
     return(
         <section>
-            <select onChange={changePage} className="selectors-admin">
+            <select onChange={changePage} className="selectors-admin" defaultValue={pageToView}>
                 <option value="Find Users">Find Users</option>
                 <option value="New Admin">New Admin</option>
                 <option value="Analytics">Analytics</option>

--- a/client/src/components/admin/AdminDropDown.jsx
+++ b/client/src/components/admin/AdminDropDown.jsx
@@ -8,6 +8,9 @@ export default function AdminDropDown({setPage, setWhichAnalyticsData, setFilter
         }else if(e.target.value === "Analytics"){
             setPage("Analytics");
             setWhichAnalyticsData("jobPostings");
+        }else if (e.target.value === "Job Postings"){
+            setPage("Job Postings");
+            setFilterType("title");
         }
     });
     return(
@@ -16,6 +19,7 @@ export default function AdminDropDown({setPage, setWhichAnalyticsData, setFilter
                 <option value="Find Users">Find Users</option>
                 <option value="New Admin">New Admin</option>
                 <option value="Analytics">Analytics</option>
+                <option value="Job Postings">Job Postings</option>
             </select>
         </section>
     )

--- a/client/src/components/admin/AdminHandler.jsx
+++ b/client/src/components/admin/AdminHandler.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import AdminDropDown from "./AdminDropDown";
 import CreateNewAdminForm from "./CreateNewAdminForm"
 import FindUserSearch from "./FindUserSearch";
@@ -7,8 +7,12 @@ import Analytics from "./Analytics/Analytics"
 import "./admin.css"
 import "../home/Home.css"
 import FindJobs from "./FindJobs";
+import { useLocation } from "react-router-dom";
 
 export default function AdminHandler(){
+    const location = useLocation();
+    const editPostingId = location.state?.editPostingId;
+    const pageToView = location.state?.pageToView;
     const[page, setPage] = useState("Find Users");
     const[filterType, setFilterType] = useState("name")
     const[filter, setFilter] = useState("");
@@ -18,12 +22,18 @@ export default function AdminHandler(){
     const handleAnalyticsChange = (e) => {
         setWhichAnalyticsData(e.target.value);
     }
+    useEffect(()=>{
+        if(pageToView){
+            console.log(pageToView)
+            setPage(pageToView);
+        }
+    },[])
     return(
         <section>
             
             <section className="subnav-container-admin">
                 <h2 className="master-text-admin">Admin Portal</h2>
-                <AdminDropDown setPage={setPage} setWhichAnalyticsData ={setWhichAnalyticsData} setFilterType = {setFilterType}/>
+                <AdminDropDown setPage={setPage} setWhichAnalyticsData ={setWhichAnalyticsData} setFilterType = {setFilterType} pageToView = {pageToView}/>
                 {page === "Find Users" && loading === false && (<FindUserSearch setFilter = {setFilter} setFilterType={setFilterType}
                 fields = {[
                     {name: "Username", value:"name"},
@@ -55,7 +65,14 @@ export default function AdminHandler(){
                 {page === "Find Users"&& (<FindUsers filter = {filter} filterType={filterType}  setFilter = {setFilter} setFilterType={setFilterType} loading={loading} setLoading={setLoading}/>)}
                 {page === "New Admin"&& (<CreateNewAdminForm/>)}
                 {page === "Analytics"&& (<Analytics whichAnalyticsData={whichAnalyticsData}/>)}
-                {page === "Job Postings"&& (<FindJobs filter={filter} filterType={filterType} setFilter = {setFilter} useFilterType = {setFilterType} loading = {loading} setLoading={setLoading}/>)}
+                {page === "Job Postings"&& (<FindJobs 
+                filter={filter} 
+                filterType={filterType} 
+                setFilter = {setFilter} 
+                useFilterType = {setFilterType} 
+                loading = {loading} 
+                setLoading={setLoading}
+                editPostingId={editPostingId}/>)}
             </section>
             
         </section>

--- a/client/src/components/admin/AdminHandler.jsx
+++ b/client/src/components/admin/AdminHandler.jsx
@@ -6,6 +6,7 @@ import FindUsers from "./FindUsers";
 import Analytics from "./Analytics/Analytics"
 import "./admin.css"
 import "../home/Home.css"
+import FindJobs from "./FindJobs";
 
 export default function AdminHandler(){
     const[page, setPage] = useState("Find Users");
@@ -23,14 +24,28 @@ export default function AdminHandler(){
             <section className="subnav-container-admin">
                 <h2 className="master-text-admin">Admin Portal</h2>
                 <AdminDropDown setPage={setPage} setWhichAnalyticsData ={setWhichAnalyticsData} setFilterType = {setFilterType}/>
-                {page === "Find Users" && loading === false && (<FindUserSearch setFilter = {setFilter} setFilterType={setFilterType}/>)}
+                {page === "Find Users" && loading === false && (<FindUserSearch setFilter = {setFilter} setFilterType={setFilterType}
+                fields = {[
+                    {name: "Username", value:"name"},
+                    {name:"Type", value:"type"},
+                    {name: "Email", value:"email"}
+                ]}
+                />)}
+                {page === "Job Postings" && loading === false && (<FindUserSearch setFilter = {setFilter} setFilterType={setFilterType}
+                fields = {[
+                    {name: "Title", value:"title"},
+                    {name: "Author", value: "author"},
+                    {name:"Status", value:"status"},
+                    {name: "Location", value:"location"}
+                ]}
+                />)}
                 {page === "Analytics" && loading === false && (
                      <section className="master-text-admin admin-selector-row-container">
                         <h3 htmlFor="analytics-select" >Select Analytics Data:</h3>
                         <select name="analytics-select" id="analytics-select" className="spacing-betteween-input-admin selectors-admin"onChange={handleAnalyticsChange}>
                             <option value="jobPostings">Job Postings</option>
                             <option value="jobFillRate">Job Posting Fill Rate</option>
-                            <option value="numUsers">Number of Users</option>
+                            <option value="numUsers">Number of Usters</option>
                         </select>
                     </section>
 
@@ -40,6 +55,7 @@ export default function AdminHandler(){
                 {page === "Find Users"&& (<FindUsers filter = {filter} filterType={filterType}  setFilter = {setFilter} setFilterType={setFilterType} loading={loading} setLoading={setLoading}/>)}
                 {page === "New Admin"&& (<CreateNewAdminForm/>)}
                 {page === "Analytics"&& (<Analytics whichAnalyticsData={whichAnalyticsData}/>)}
+                {page === "Job Postings"&& (<FindJobs filter={filter} filterType={filterType} setFilter = {setFilter} useFilterType = {setFilterType} loading = {loading} setLoading={setLoading}/>)}
             </section>
             
         </section>

--- a/client/src/components/admin/EditJobs.jsx
+++ b/client/src/components/admin/EditJobs.jsx
@@ -1,0 +1,82 @@
+import { validateCreateJobForm } from "../../utils/validation/validateCreateJobForm";
+import { useEffect, useState } from "react"
+import {jobPostingApi } from "../../utils/api";
+import "../common/Card.css"
+import { useForm } from "react-hook-form";
+export default function EditJobs({setXButton, jobDetails, allCards, setAllCards, setFilteredCards}){
+     const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+        const {register, handleSubmit} = useForm();
+        const [thisTitle, setThisTitle] = useState(jobDetails.title);
+        const [errors, setErrors] = useState({});
+        const [editAdmin, setEditAdmin] = useState(false);
+    
+        const onSubmit = (async (updatedAdminInfo)=>{
+            try {
+                const inputError = validateCreateJobForm({title: updatedAdminInfo.title, location: updatedAdminInfo.location, description: updatedAdminInfo.description});
+                setErrors(inputError);
+                console.log("Validation errors:", inputError);
+                if (Object.keys(inputError).length > 0) {
+                    return;
+                }
+                const payload = {
+                    title: updatedAdminInfo.title,
+                    location: updatedAdminInfo.location,
+                    description: updatedAdminInfo.description,
+                    tags: updatedAdminInfo.tags?updatedAdminInfo.tags.split(", "): []
+                };
+                await jobPostingApi.update(jobDetails.id, payload);
+                console.log(allCards);
+                const newEntry = {
+                    _id: jobDetails.id,
+                    title: updatedAdminInfo.title,
+                    location: updatedAdminInfo.location,
+                    author: jobDetails.author,
+                    tags: updatedAdminInfo.tags,
+                    status: jobDetails.status,
+                    description: updatedAdminInfo.description,
+
+                };
+                setThisTitle(updatedAdminInfo.title);
+                const updatedList = [
+                ...allCards.filter((job) => job._id !== jobDetails.id),
+                newEntry];
+                setAllCards(updatedList);
+                setFilteredCards(updatedList);
+                setEditAdmin(true);
+                await delay(2000);
+                setEditAdmin(false);
+                } catch (error) {
+                    console.error("Error updating admin information:", error);
+                }
+            });
+        return(
+    
+            <section className="modal-overlay">
+                <section className="registerCardAdmin" style={{"position": "relative", "border width": "2px", "border color": "black"}}> 
+                    <span className="Exit-Button" onClick={() => setXButton()}>X</span>
+                    <section>
+                        <h1>Edit {thisTitle}</h1>
+                        <form className="editJobForm"onSubmit={handleSubmit(onSubmit)}>
+                            <label htmlFor="">Title:
+                            <input type="text" name="" id="" defaultValue={jobDetails.title} {...register("title")}/>
+                            </label>
+                            {errors.title && <p className="error">{errors.title}</p>}
+                            <label htmlFor="">Location
+                            <input type="text" name="" id="" defaultValue={jobDetails.location} {...register("location")}/>
+                            </label>
+                            {errors.location && <p className="error">{errors.location}</p>}
+                            <label htmlFor="" >Description:
+                            <textarea type="text" name="" id="" defaultValue={jobDetails.description} {...register("description")}/>
+                            </label>
+                            {errors.description && <p className="error">{errors.description}</p>}
+                            <label htmlFor="">Tags:
+                            <input type="text" name="" id=""  defaultValue={jobDetails.tags} {...register("tags")}/>
+                            </label>
+                            <button type="submit">Save</button>
+                            {editAdmin && <p className="success">Job Updated successfully!</p>}
+                        </form>
+                    </section>
+                </section>
+            </section>
+        )
+}

--- a/client/src/components/admin/EditJobs.jsx
+++ b/client/src/components/admin/EditJobs.jsx
@@ -24,10 +24,10 @@ export default function EditJobs({setXButton, jobDetails, allCards, setAllCards,
                     description: updatedAdminInfo.description,
                     tags: updatedAdminInfo.tags?updatedAdminInfo.tags.split(", "): []
                 };
-                await jobPostingApi.update(jobDetails.id, payload);
+                await jobPostingApi.update(jobDetails._id, payload);
                 console.log(allCards);
                 const newEntry = {
-                    _id: jobDetails.id,
+                    _id: jobDetails._id,
                     title: updatedAdminInfo.title,
                     location: updatedAdminInfo.location,
                     author: jobDetails.author,
@@ -38,7 +38,7 @@ export default function EditJobs({setXButton, jobDetails, allCards, setAllCards,
                 };
                 setThisTitle(updatedAdminInfo.title);
                 const updatedList = [
-                ...allCards.filter((job) => job._id !== jobDetails.id),
+                ...allCards.filter((job) => job._id !== jobDetails._id),
                 newEntry];
                 setAllCards(updatedList);
                 setFilteredCards(updatedList);

--- a/client/src/components/admin/FindJobs.jsx
+++ b/client/src/components/admin/FindJobs.jsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react"
+import { adminApi,jobPostingApi } from "../../utils/api";
+import "../common/Card.css"
+import DeletePopup from "./DeletePopup";
+import JobPostingCard from "./JobPostingCard";
+import EditJobs from "./EditJobs";
+import CloseStatus from "../company-portal/CloseStatus";
+export default function FindJobs({filterType, filter, loading, setLoading}){
+        const [filteredCards, setFilteredCards] = useState([]);
+        const [allCards, setAllCards] = useState([]);
+        const [xButton, setXButton] = useState(true);
+        const [xButtonClousre, setXButtonClousre] = useState(true);
+        const [editJobsInfo, setEditJobsInfo] = useState({});
+        const [deletePopup, setDeletePopup] = useState(false);
+        const [eventForClousre, setEventForClousre] = useState(false);
+        const [postingToClose, setPostingToClose] = useState(null);
+        const xButtonSwitch = (()=>{
+            setXButton((prev)=>!prev);
+        })
+        const deletePopupSwitch = (()=>{
+            setDeletePopup((prev)=>!prev);
+        })
+        const xButtonClousreSwitch = (()=>{
+            setXButtonClousre((prev)=>!prev);
+        });
+        //Load all users into allCards and filteredCards
+        useEffect(() => {
+            const loadData = (async ()=>{
+                try{
+                const response = await jobPostingApi.getAll();
+                setFilteredCards(response);
+                setAllCards(response);
+                console.log("Loaded jobs:", response);
+                setLoading(false);
+            }catch(e){
+                console.log("Error",e);
+            }
+            })
+            loadData();
+        }, []);
+    
+    
+    
+        //Search allCards for all the includes in filter based on filterType
+        useEffect(()=>{
+                if(!filter){
+                setFilteredCards(allCards);
+                return;
+            }
+            setFilteredCards(
+                allCards.filter((user)=>
+                user[filterType]?.toLowerCase().includes(filter.toLowerCase())
+                )
+            );
+        
+        }, [filter, filterType, allCards]);
+        const deleteJob = async(id) => {
+            console.log("Deleting Job with id:", id);
+            const updated = allCards.filter((job) => job._id !== id);
+            setAllCards(updated);
+            setFilteredCards(updated);
+            try{
+                await jobPostingApi.delete(id);
+                deletePopupSwitch();
+            }catch(e){
+                console.log("Error",e);
+            }
+    
+        }
+        const handleStatusChange = async (jobId, newStatus, closureReason) => {
+        try {
+            console.log(jobId,newStatus)
+            console.log(closureReason)
+            await jobPostingApi.updateStatus(jobId, newStatus, closureReason);
+            const newCards = allCards.map((prev) =>
+                (prev._id === jobId ? { ...prev, status: newStatus, ...(newStatus === "CLOSED" && closureReason ? { closureReason } : {}) } : prev)
+            );
+            console.log(newCards)
+            setAllCards(newCards);
+            setFilteredCards(newCards);
+        }
+        catch (err) {
+            console.error("Failed to update status:", err);
+        }
+        };
+        return(
+            <>
+                {!loading&& (<section className="job-postings-layout">
+                    {filteredCards.map((card)=>(
+                        <JobPostingCard key ={card._id} jobPosting={card} deletePopupSwitch={deletePopupSwitch} xButtonSwitch ={xButtonSwitch} setEditJobsInfo = {setEditJobsInfo}
+                        updateStatus = {handleStatusChange} xButtonClousreSwitch={xButtonClousreSwitch} setPostingToClose ={setPostingToClose}
+                        />
+                        ))}
+                </section>)}
+                {!xButton &&editJobsInfo&&(<EditJobs setXButton={xButtonSwitch}  jobDetails={editJobsInfo} allCards={allCards} setAllCards={setAllCards} setFilteredCards={setFilteredCards}/>)}
+                <CloseStatus postingToClose={postingToClose} onClose={() => setPostingToClose(null)} onClosePosting={(jobId, closureReason) => handleStatusChange(jobId, "CLOSED", closureReason)} />
+                {deletePopup && (<DeletePopup deletePopupSwitch={deletePopupSwitch} deleteFunction={()=>deleteJob(editJobsInfo._id)}/>)}
+                {filteredCards.length === 0 && (<p>No Users match your search. </p>)}
+                {loading &&(<p>Loading....</p>)}
+            </>
+        )
+}

--- a/client/src/components/admin/FindJobs.jsx
+++ b/client/src/components/admin/FindJobs.jsx
@@ -5,7 +5,8 @@ import DeletePopup from "./DeletePopup";
 import JobPostingCard from "./JobPostingCard";
 import EditJobs from "./EditJobs";
 import CloseStatus from "../company-portal/CloseStatus";
-export default function FindJobs({filterType, filter, loading, setLoading}){
+import { useNavigate } from "react-router-dom";
+export default function FindJobs({filterType, filter, loading, setLoading, editPostingId}){
         const [filteredCards, setFilteredCards] = useState([]);
         const [allCards, setAllCards] = useState([]);
         const [xButton, setXButton] = useState(true);
@@ -14,6 +15,7 @@ export default function FindJobs({filterType, filter, loading, setLoading}){
         const [deletePopup, setDeletePopup] = useState(false);
         const [eventForClousre, setEventForClousre] = useState(false);
         const [postingToClose, setPostingToClose] = useState(null);
+        const navigate = useNavigate();
         const xButtonSwitch = (()=>{
             setXButton((prev)=>!prev);
         })
@@ -38,6 +40,22 @@ export default function FindJobs({filterType, filter, loading, setLoading}){
             })
             loadData();
         }, []);
+        useEffect(() => {
+            console.log("I ran")
+            if (!editPostingId || !allCards.length) return;
+
+            const postingToEdit = allCards.find(
+                (posting) => String(posting._id) === String(editPostingId)
+            );
+
+            if (postingToEdit) {
+                console.log(postingToEdit);
+                setEditJobsInfo(postingToEdit);
+                xButtonSwitch();
+                navigate(location.pathname, { replace: true, state: {} });
+            }
+        }, [editPostingId, allCards]);
+
     
     
     
@@ -75,7 +93,6 @@ export default function FindJobs({filterType, filter, loading, setLoading}){
             const newCards = allCards.map((prev) =>
                 (prev._id === jobId ? { ...prev, status: newStatus, ...(newStatus === "CLOSED" && closureReason ? { closureReason } : {}) } : prev)
             );
-            console.log(newCards)
             setAllCards(newCards);
             setFilteredCards(newCards);
         }

--- a/client/src/components/admin/FindUserSearch.jsx
+++ b/client/src/components/admin/FindUserSearch.jsx
@@ -1,4 +1,4 @@
-export default function({setFilter,setFilterType}){
+export default function({setFilter,setFilterType, fields}){
     const changeFilterType = ((e)=>{
         setFilterType(e.target.value);
     })
@@ -9,9 +9,9 @@ export default function({setFilter,setFilterType}){
         <section className="master-text-admin admin-selector-row-container">
             <h3>Search By:</h3>
             <select name="" id="" onChange={changeFilterType} className="spacing-betteween-input-admin selectors-admin">
-                <option value="name">Username</option>
-                <option value="type">Type</option>
-                <option value="email">Email</option>
+                {fields.map((field)=>(
+                    <option id ={field.value} value={field.value}>{field.name}</option>
+                ))}
             </select>
             <input type="text" name="" id="searchTextInput" placeholder="..." onChange={changeFilter} className="spacing-betteween-input-admin input-box-admin"/>
         </section>

--- a/client/src/components/admin/JobPostingCard.jsx
+++ b/client/src/components/admin/JobPostingCard.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+export default function({jobPosting, setPostingToClose,xButtonSwitch, setEditJobsInfo, updateStatus,deletePopupSwitch, xButtonClousreSwitch}){
+    //const [newStatus, setNewStatus] = useState(null);
+    //useEffect(()=>{
+
+    //},[newStatus])
+    return(
+        <section className="card-container">
+            <h1 className="card-title">{jobPosting.title}</h1>
+            <p className="card-body">Auhtor: {jobPosting.author}</p>
+            <p className="card-body">Location: {jobPosting.location}</p>
+            <select name="" id="" className="card-actions card-selector-admin" onChange={(e)=>{
+                 const newStatus=e.target.value;
+                if (newStatus === 'CLOSED') setPostingToClose(jobPosting);
+                else updateStatus(jobPosting._id, newStatus);
+                  }} value={jobPosting.status}>
+                <option value="ACTIVE">Active</option>
+                <option value="UNPUBLISHED">Unpublished</option>
+                <option value="CLOSED">Closed</option>
+            </select>
+            <button className="card-actions card-admin-button" onClick={() => {
+                setEditJobsInfo(jobPosting);
+                xButtonSwitch();
+            }}>Edit</button>
+            <button className="card-actions card-admin-button" onClick={() => {
+                setEditJobsInfo(jobPosting);
+                deletePopupSwitch();
+                }}>Delete</button>
+        </section>
+)
+}

--- a/client/src/components/admin/__tests__/EditJobs.test.jsx
+++ b/client/src/components/admin/__tests__/EditJobs.test.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import EditJobs from "../EditJobs";
+import { jobPostingApi } from "../../../utils/api";
+import * as validation from "../../../utils/validation/validateCreateJobForm";
+jest.mock("../../../utils/api", () => ({ jobPostingApi: { update: jest.fn() } }));
+jest.mock("../../../utils/validation/validateCreateJobForm", () => ({
+  validateCreateJobForm: jest.fn(),
+}));
+const jobDetails = { id: "j1", title: "Frontend Dev", location: "Remote", description: "UI work", tags: [], author: "TechCorp", status: "ACTIVE" };
+const makeProps = () => ({ setXButton: jest.fn(), jobDetails, allCards: [{ _id: "j1", ...jobDetails }], setAllCards: jest.fn(), setFilteredCards: jest.fn() });
+beforeEach(() => {
+  validation.validateCreateJobForm.mockReturnValue({});
+  jobPostingApi.update.mockResolvedValue({});
+});
+it("pre fills inputs with job details", () => {
+  render(<EditJobs {...makeProps()} />);
+  expect(screen.getByDisplayValue("Frontend Dev")).toBeInTheDocument();
+  expect(screen.getByDisplayValue("Remote")).toBeInTheDocument();
+});
+it("block submit and show error, validation fails", async () => {
+  validation.validateCreateJobForm.mockReturnValue({ title: "Title required" });
+  render(<EditJobs {...makeProps()} />);
+  await act(async () => fireEvent.click(screen.getByRole("button", { name: /save/i })));
+  expect(screen.getByText("Title required")).toBeInTheDocument();
+  expect(jobPostingApi.update).not.toHaveBeenCalled();
+});
+it("calls update api on submit", async () => {
+  render(<EditJobs {...makeProps()} />);
+  await act(async () => fireEvent.click(screen.getByRole("button", { name: /save/i })));
+  await waitFor(() => expect(jobPostingApi.update).toHaveBeenCalledWith("j1", expect.objectContaining({ title: "Frontend Dev" })));
+});

--- a/client/src/components/admin/__tests__/FindJobs.test.jsx
+++ b/client/src/components/admin/__tests__/FindJobs.test.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import FindJobs from "../FindJobs";
+import { jobPostingApi } from "../../../utils/api";
+
+jest.mock("../../../utils/api", () => ({
+  jobPostingApi: { getAll: jest.fn(), delete: jest.fn(), updateStatus: jest.fn() },
+}));
+jest.mock("../JobPostingCard", () => ({ jobPosting, deletePopupSwitch, setEditJobsInfo }) => (
+  <div data-testid={`card-${jobPosting._id}`}>
+    <span>{jobPosting.title}</span>
+    <button onClick={() => { setEditJobsInfo(jobPosting); deletePopupSwitch(); }}>Delete</button>
+  </div>
+));
+jest.mock("../EditJobs", () => () => <div />);
+jest.mock("../DeletePopup", () => ({ deleteFunction }) => <button onClick={deleteFunction}>Confirm Delete</button>);
+jest.mock("../../company-portal/CloseStatus", () => () => <div />);
+const mockJobs = [
+  { _id: "j1", title: "Frontend Dev", author: "TechCorp", location: "Remote", status: "ACTIVE" },
+  { _id: "j2", title: "Backend Eng", author: "StartupXYZ", location: "Vancouver", status: "CLOSED" },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jobPostingApi.getAll.mockResolvedValue(mockJobs);
+  jobPostingApi.delete.mockResolvedValue({});
+});
+
+it("render all job card after fetch", async () => {
+  render(<FindJobs filter="" filterType="title" loading={false} setLoading={jest.fn()} />);
+  await waitFor(() => expect(screen.getByTestId("card-j1")).toBeInTheDocument());
+  expect(screen.getByTestId("card-j2")).toBeInTheDocument();
+});
+
+it("filter card by the filter", async () => {
+  render(<FindJobs filter="Frontend" filterType="title" loading={false} setLoading={jest.fn()} />);
+  await waitFor(() => expect(screen.getByTestId("card-j1")).toBeInTheDocument());
+  expect(screen.queryByTestId("card-j2")).not.toBeInTheDocument();
+});
+
+it("delete job and remove it from the list", async () => {
+  render(<FindJobs filter="" filterType="title" loading={false} setLoading={jest.fn()} />);
+  await waitFor(() => expect(screen.getByTestId("card-j1")).toBeInTheDocument());
+  act(() => screen.getAllByText("Delete")[0].click());
+  act(() => screen.getByText("Confirm Delete").click());
+  await waitFor(() => expect(screen.queryByTestId("card-j1")).not.toBeInTheDocument());
+});

--- a/client/src/components/admin/__tests__/FindUserSearch.test.jsx
+++ b/client/src/components/admin/__tests__/FindUserSearch.test.jsx
@@ -5,8 +5,9 @@ import FindUserSearch from '../FindUserSearch.jsx'
 function setup() {
     const setFilter = jest.fn()
     const setFilterType = jest.fn()
-    render(<FindUserSearch setFilter={setFilter} setFilterType={setFilterType} filters={[
-        {name:"Name", value:"name"}
+    render(<FindUserSearch setFilter={setFilter} setFilterType={setFilterType} fields={[
+        {name:"Name", value:"name"},
+        {name:"Type", value:"type"}
     ]}/>)
     return { setFilter, setFilterType }
 }

--- a/client/src/components/admin/__tests__/FindUserSearch.test.jsx
+++ b/client/src/components/admin/__tests__/FindUserSearch.test.jsx
@@ -5,7 +5,9 @@ import FindUserSearch from '../FindUserSearch.jsx'
 function setup() {
     const setFilter = jest.fn()
     const setFilterType = jest.fn()
-    render(<FindUserSearch setFilter={setFilter} setFilterType={setFilterType} />)
+    render(<FindUserSearch setFilter={setFilter} setFilterType={setFilterType} filters={[
+        {name:"Name", value:"name"}
+    ]}/>)
     return { setFilter, setFilterType }
 }
 

--- a/client/src/components/admin/__tests__/JobPostingCard.test.jsx
+++ b/client/src/components/admin/__tests__/JobPostingCard.test.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import JobPostingCard from "../JobPostingCard";
+const posting = { _id: "j1", title: "Frontend Dev", author: "TechCorp", location: "Remote", status: "ACTIVE" };
+const makeProps = (overrides = {}) => ({
+  jobPosting: posting,
+  setPostingToClose: jest.fn(),
+  xButtonSwitch: jest.fn(),
+  setEditJobsInfo: jest.fn(),
+  updateStatus: jest.fn(),
+  deletePopupSwitch: jest.fn(),
+  ...overrides,
+});
+it("render title, author, and location", () => {
+  render(<JobPostingCard {...makeProps()} />);
+  expect(screen.getByText("Frontend Dev")).toBeInTheDocument();
+  expect(screen.getByText(/TechCorp/)).toBeInTheDocument();
+  expect(screen.getByText(/Remote/)).toBeInTheDocument();
+});
+it("shows the cur status as selected", () => {
+  render(<JobPostingCard {...makeProps()} />);
+  expect(screen.getByRole("combobox").value).toBe("ACTIVE");
+});
+it("call setPostingToClos when changed to CLOSED", () => {
+  const props = makeProps();
+  render(<JobPostingCard {...props} />);
+  fireEvent.change(screen.getByRole("combobox"), { target: { value: "CLOSED" } });
+  expect(props.setPostingToClose).toHaveBeenCalledWith(posting);
+  expect(props.updateStatus).not.toHaveBeenCalled();
+});
+it("calls updateStatus when changed to a non-CLOSED status", () => {
+  const props = makeProps();
+  render(<JobPostingCard {...props} />);
+  fireEvent.change(screen.getByRole("combobox"), { target: { value: "UNPUBLISHED" } });
+  expect(props.updateStatus).toHaveBeenCalledWith("j1", "UNPUBLISHED");
+});
+it("Edit button calls setEditJobsInfo and xButtonSwitch", () => {
+  const props = makeProps();
+  render(<JobPostingCard {...props} />);
+  fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+  expect(props.setEditJobsInfo).toHaveBeenCalledWith(posting);
+  expect(props.xButtonSwitch).toHaveBeenCalled();
+});
+it("Make sure Delete button calls setEditJobsInfo and deletePopupSwitch", () => {
+  const props = makeProps();
+  render(<JobPostingCard {...props} />);
+  fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+  expect(props.setEditJobsInfo).toHaveBeenCalledWith(posting);
+  expect(props.deletePopupSwitch).toHaveBeenCalled();
+});

--- a/client/src/components/admin/admin.css
+++ b/client/src/components/admin/admin.css
@@ -8,6 +8,9 @@
     padding: 5px 10px;
     cursor: pointer;
 }
+.editJobForm label{
+    width: 80%;
+}
 .modal-overlay {
     position: fixed;
     top: 0;
@@ -126,6 +129,18 @@
     border-radius: 8px;
     background: var(--color-card-bg);
 }
+.registerCardAdmin textarea {
+    resize: none;
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    font-family: "Source Serif Pro", Georgia, serif;
+    padding: 0 8px;
+    border: 1px solid var(--color-divider);
+    border-radius: 8px;
+    background: var(--color-card-bg);
+}
+
 
 .registerCardAdmin input::placeholder {
     color: var(--color-text-placeholder);

--- a/client/src/components/admin/admin.css
+++ b/client/src/components/admin/admin.css
@@ -33,7 +33,7 @@
     padding: 5px;
 }
 .card-admin-button{
-    width: 40%;
+    width: 50%;
     align-self: center;
     padding: 10px 0px;
     background-color: var(--color-cta-primary);

--- a/client/src/components/home/JobDetailsForm.jsx
+++ b/client/src/components/home/JobDetailsForm.jsx
@@ -56,7 +56,12 @@ export default function JobDetailsForm({ posting, role, userId, isAuthenticated,
         }
 
         if (role === "administrator") {
-            // TODO: take the user to the admin portal, and highlight the specific job they are looking at OR open the modal (whatever is implemented)
+            navigate('/admin', {
+                state: {
+                    editPostingId: posting._id,
+                    pageToView: "Job Postings",
+                },
+            });
             return;
         }
     }

--- a/server/repository/company.repository.js
+++ b/server/repository/company.repository.js
@@ -80,6 +80,7 @@ const companyRepository = {
       tags: jobData.tags ?? [],
       status: 'ACTIVE',
       publishedAt: new Date(),
+      author: companyId
     });
 
     company.jobPostings.push(job._id);

--- a/server/repository/jobPosting.repository.js
+++ b/server/repository/jobPosting.repository.js
@@ -65,10 +65,14 @@ const jobPostingRepository = {
   },
 
   async delete(id) {
+    console.log("start delete")
     await Company.updateOne({ jobPostings: id }, { $pull: { jobPostings: id } });
+    console.log("Upaded company")
     const deleted = await JobPosting.findByIdAndDelete(id);
     if (!deleted) return null;
-    await Applicant.updateMany({ jobsAppliedTo: id }, { $pull: { jobsAppliedTo: id } });
+    console.log("deleted")
+    await Applicant.updateMany({ jobsAppliedTo: { job: id } }, { $pull: { jobsAppliedTo: { job: id } } });
+    console.log("Updated many")
     return deleted;
   },
 

--- a/server/repository/models/jobPosting.model.js
+++ b/server/repository/models/jobPosting.model.js
@@ -14,6 +14,7 @@ const jobPostingSchema = new mongoose.Schema({
     enum: JOB_STATUSES,
     default: 'ACTIVE',
   },
+  author: { type:String},
   closureReason: { type: String, enum: JOB_CLOSURE_REASONS },
   publishedAt: { type: Date },
   closedAt: { type: Date },

--- a/server/scripts/seed.js
+++ b/server/scripts/seed.js
@@ -60,7 +60,7 @@ async function seed() {
   // create job postings
   const jobPostings = await JobPosting.insertMany([
     // TechCorp
-    { title: 'Senior Frontend Developer', tags: ['React', 'JavaScript'], location: 'Remote', description: 'Build great UIs.', status: 'ACTIVE', publishedAt: daysAgo(14) },
+    { title: 'Senior Frontend Developer', tags: ['React', 'JavaScript'], location: 'Remote', description: 'Build great UIs.', status: 'ACTIVE', publishedAt: daysAgo(14)},
     { title: 'Backend Engineer', tags: ['Node.js', 'MongoDB'], location: 'Vancouver', description: 'APIs and databases.', status: 'CLOSED', closureReason: 'FILLED', publishedAt: daysAgo(45), closedAt: daysAgo(10) },
     { title: 'DevOps Engineer', tags: ['AWS', 'Docker', 'Kubernetes'], location: 'Remote', description: 'Infrastructure and CI/CD.', status: 'ACTIVE', publishedAt: daysAgo(7) },
     // StartupXYZ
@@ -83,6 +83,24 @@ async function seed() {
   await Company.findByIdAndUpdate(companies[2]._id, { jobPostings: [jobPostings[6]._id, jobPostings[7]._id, jobPostings[8]._id] });
   await Company.findByIdAndUpdate(companies[3]._id, { jobPostings: [jobPostings[9]._id, jobPostings[10]._id, jobPostings[11]._id] });
 
+  //link companies to job postings
+  //Tech Corp
+  await JobPosting.findByIdAndUpdate(jobPostings[0]._id, {author: companies[0].name})
+  await JobPosting.findByIdAndUpdate(jobPostings[1]._id, {author: companies[0].name})
+  await JobPosting.findByIdAndUpdate(jobPostings[2]._id, {author: companies[0].name})
+
+  //StartUpXYZ
+  await JobPosting.findByIdAndUpdate(jobPostings[3]._id, {author: companies[1].name});
+  await JobPosting.findByIdAndUpdate(jobPostings[4]._id, {author: companies[1].name});
+  await JobPosting.findByIdAndUpdate(jobPostings[5]._id, {author: companies[1].name});
+  // DataFlow Inc
+  await JobPosting.findByIdAndUpdate(jobPostings[6]._id, {author: companies[2].name});
+  await JobPosting.findByIdAndUpdate(jobPostings[7]._id, {author: companies[2].name});
+  await JobPosting.findByIdAndUpdate(jobPostings[8]._id, {author: companies[2].name});
+  // CloudNine
+  await JobPosting.findByIdAndUpdate(jobPostings[9]._id, {author: companies[3].name});
+  await JobPosting.findByIdAndUpdate(jobPostings[10]._id, {author: companies[3].name});
+  await JobPosting.findByIdAndUpdate(jobPostings[11]._id, {author: companies[3].name});
   // link applicants to job postings
   await JobPosting.findByIdAndUpdate(jobPostings[0]._id, { applicants: [applicants[0]._id, applicants[1]._id, applicants[2]._id, applicants[3]._id] });
   await JobPosting.findByIdAndUpdate(jobPostings[1]._id, { applicants: [applicants[0]._id, applicants[1]._id, applicants[2]._id] });


### PR DESCRIPTION
### Admins can now view/delete/edit all job posting.
They can filter with the following filters

- Title
- Author
- Location
- Status
I did not add Tags as I feel that admins would not have a use case for querying by tags.

### Changes made to schema
added author to job postings schema which is the name of the company that made the job posting

**Bug fixes**
Fixed issue with jobPosting.getAll() where the promise would get hung when it tried to get all the job applications for the job postings. Cause was a nesting error Fix was to call Applicant ({job: {_id}})